### PR TITLE
BAU: Move to correct packages

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
@@ -1,4 +1,4 @@
-package di.ipv.cri.passport.helpers;
+package uk.gov.di.ipv.cri.passport.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -1,10 +1,10 @@
-package di.ipv.cri.passport.lambda;
+package uk.gov.di.ipv.cri.passport.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
 import org.apache.http.HttpStatus;
 
 public class PassportHandler


### PR DESCRIPTION
## Proposed changes

### What changed

Move classes so that they are in packages starting `uk.gov.di.ipv`

### Why did it change

We should keep a consistent package space across our project. They should all start `uk.gov.di.ipv`
