### PR TITLE
PYI-438: Handle passport form data from frontend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
 			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
 			"org.slf4j:slf4j-simple:1.7.32"
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',

--- a/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
@@ -1,0 +1,39 @@
+package uk.gov.di.ipv.cri.passport.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public class DcsCheckRequestDto {
+
+    private static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final String timeZone = "UTC";
+
+    private final String passportNumber;
+    private final String surname;
+
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private final String[] forenames;
+
+    @JsonFormat(pattern = dateFormat, timezone = timeZone)
+    private final Instant dateOfBirth;
+
+    @JsonFormat(pattern = dateFormat, timezone = timeZone)
+    private final Instant expiryDate;
+
+    @JsonCreator
+    public DcsCheckRequestDto(
+            @JsonProperty(value = "passportNumber", required = true) String passportNumber,
+            @JsonProperty(value = "surname", required = true) String surname,
+            @JsonProperty(value = "forenames", required = true) String[] forenames,
+            @JsonProperty(value = "dateOfBirth", required = true) Instant dateOfBirth,
+            @JsonProperty(value = "expiryDate", required = true) Instant expiryDate) {
+        this.passportNumber = passportNumber;
+        this.surname = surname;
+        this.forenames = forenames;
+        this.dateOfBirth = dateOfBirth;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.cri.passport.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorResponse {
+    FAILED_TO_PARSE_PASSPORT_FORM_DATA(1000, "Failed to parse passport form data");
+
+    private final int code;
+    private final String message;
+
+    ErrorResponse(
+            @JsonProperty(required = true, value = "code") int code,
+            @JsonProperty(required = true, value = "message") String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.passport.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,8 @@ import java.util.Map;
 public class ApiGatewayResponseGenerator {
 
     private static final String JSON_CONTENT_TYPE_VALUE = "application/json";
-
+    private static final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseGenerator.class);
 
     private ApiGatewayResponseGenerator() {}
@@ -42,6 +44,6 @@ public class ApiGatewayResponseGenerator {
     }
 
     private static <T> String generateResponseBody(T body) throws JsonProcessingException {
-        return new ObjectMapper().writeValueAsString(body);
+        return objectMapper.writeValueAsString(body);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -4,16 +4,36 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.passport.dto.DcsCheckRequestDto;
+import uk.gov.di.ipv.cri.passport.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
 
 public class PassportHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PassportHandler.class);
+    private static final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
 
-        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, "Hello world");
+        DcsCheckRequestDto dcsCheckRequestDto;
+        try {
+            dcsCheckRequestDto = objectMapper.readValue(input.getBody(), DcsCheckRequestDto.class);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Passport form data could not be parsed", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA);
+        }
+
+        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, dcsCheckRequestDto);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
@@ -1,0 +1,87 @@
+package uk.gov.di.ipv.cri.passport.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.error.ErrorResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class PassportHandlerTest {
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+    private final PassportHandler passportHandler = new PassportHandler();
+    private final Map<String, String> validPassportFormData =
+            Map.of(
+                    "passportNumber", "1234567890",
+                    "surname", "Tattsyrup",
+                    "forenames", "[Tubbs]",
+                    "dateOfBirth", "1984-09-28T10:15:30",
+                    "expiryDate", "2024-09-03T10:15:30");
+
+    @Mock private Context context;
+
+    @Test
+    void shouldReturn200WithCorrectFormData() throws JsonProcessingException {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = passportHandler.handleRequest(event, context);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturn400IfDataIsMissing() throws JsonProcessingException {
+        var formFields = validPassportFormData.keySet();
+        for (String keyToRemove : formFields) {
+            var event = new APIGatewayProxyRequestEvent();
+            event.setBody(
+                    objectMapper.writeValueAsString(
+                            new HashMap<>(validPassportFormData).remove(keyToRemove)));
+
+            var response = passportHandler.handleRequest(event, context);
+            var responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+            assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+            assertEquals(
+                    ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA.getCode(),
+                    responseBody.get("code"));
+            assertEquals(
+                    ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA.getMessage(),
+                    responseBody.get("message"));
+        }
+    }
+
+    @Test
+    void shouldReturn400IfDateStringsAreWrongFormat() throws JsonProcessingException {
+        var mangledDateInput = new HashMap<>(validPassportFormData);
+        mangledDateInput.put("dateOfBirth", "1984-09-28T10:15:30.00Z");
+
+        var event = new APIGatewayProxyRequestEvent();
+        event.setBody(objectMapper.writeValueAsString(mangledDateInput));
+
+        var response = passportHandler.handleRequest(event, context);
+        var responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA.getMessage(),
+                responseBody.get("message"));
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds logic to the passport handler to receive the passport details
in the body of the request and convert them to a DTO.

We do some light validation on the DTO to give us confidence that we're
not getting junk from the frontend.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-438](https://govukverify.atlassian.net/browse/PYI-438)
