### PR TITLE
PYI-459: Remove timestamp from passport date fields 

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.Instant;
+import java.time.LocalDate;
 
 public class DcsCheckRequestDto {
 
-    private static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final String dateFormat = "yyyy-MM-dd";
     private static final String timeZone = "UTC";
 
     private final String passportNumber;
@@ -18,18 +18,18 @@ public class DcsCheckRequestDto {
     private final String[] forenames;
 
     @JsonFormat(pattern = dateFormat, timezone = timeZone)
-    private final Instant dateOfBirth;
+    private final LocalDate dateOfBirth;
 
     @JsonFormat(pattern = dateFormat, timezone = timeZone)
-    private final Instant expiryDate;
+    private final LocalDate expiryDate;
 
     @JsonCreator
     public DcsCheckRequestDto(
             @JsonProperty(value = "passportNumber", required = true) String passportNumber,
             @JsonProperty(value = "surname", required = true) String surname,
             @JsonProperty(value = "forenames", required = true) String[] forenames,
-            @JsonProperty(value = "dateOfBirth", required = true) Instant dateOfBirth,
-            @JsonProperty(value = "expiryDate", required = true) Instant expiryDate) {
+            @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
+            @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate) {
         this.passportNumber = passportNumber;
         this.surname = surname;
         this.forenames = forenames;

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class PassportHandlerTest {
+class PassportHandlerTest {
 
     private final ObjectMapper objectMapper =
             new ObjectMapper().registerModule(new JavaTimeModule());
@@ -28,8 +28,8 @@ public class PassportHandlerTest {
                     "passportNumber", "1234567890",
                     "surname", "Tattsyrup",
                     "forenames", "[Tubbs]",
-                    "dateOfBirth", "1984-09-28T10:15:30",
-                    "expiryDate", "2024-09-03T10:15:30");
+                    "dateOfBirth", "1984-09-28",
+                    "expiryDate", "2024-09-03");
 
     @Mock private Context context;
 
@@ -68,7 +68,7 @@ public class PassportHandlerTest {
     @Test
     void shouldReturn400IfDateStringsAreWrongFormat() throws JsonProcessingException {
         var mangledDateInput = new HashMap<>(validPassportFormData);
-        mangledDateInput.put("dateOfBirth", "1984-09-28T10:15:30.00Z");
+        mangledDateInput.put("dateOfBirth", "28-09-1984");
 
         var event = new APIGatewayProxyRequestEvent();
         event.setBody(objectMapper.writeValueAsString(mangledDateInput));


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove timestamp requirement of the passport date fields.
Remove public class modifier in test that is recognised as a code smell within sonar.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
DCS service expects the dates in the format YYYY-MM-DD so the timestamp is not required, and the front-end does not provide any time values.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-459](https://govukverify.atlassian.net/browse/PYI-459)

