### PR TITLE
PYI-465: Generate KMS keys for use with DCS

### DIFF
--- a/terraform/lambda/kms.tf
+++ b/terraform/lambda/kms.tf
@@ -4,6 +4,10 @@ resource "aws_kms_key" "signing" {
   customer_master_key_spec = "RSA_2048"
   policy                   = data.aws_iam_policy_document.kms_key_access.json
   tags                     = local.default_tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_kms_alias" "signing" {
@@ -17,6 +21,10 @@ resource "aws_kms_key" "encryption" {
   customer_master_key_spec = "RSA_2048"
   policy                   = data.aws_iam_policy_document.kms_key_access.json
   tags                     = local.default_tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_kms_alias" "encryption" {

--- a/terraform/lambda/kms.tf
+++ b/terraform/lambda/kms.tf
@@ -1,0 +1,108 @@
+resource "aws_kms_key" "signing" {
+  description              = "Signing key for messages sent to DCS"
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "RSA_2048"
+  policy                   = data.aws_iam_policy_document.kms_key_access.json
+  tags                     = local.default_tags
+}
+
+resource "aws_kms_alias" "signing" {
+  name          = "alias/${var.environment}/cri/passport/signing"
+  target_key_id = aws_kms_key.signing.key_id
+}
+
+resource "aws_kms_key" "encryption" {
+  description              = "Encryption key for messages from DCS"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "RSA_2048"
+  policy                   = data.aws_iam_policy_document.kms_key_access.json
+  tags                     = local.default_tags
+}
+
+resource "aws_kms_alias" "encryption" {
+  name          = "alias/${var.environment}/cri/passport/encryption"
+  target_key_id = aws_kms_key.encryption.key_id
+}
+
+data "aws_iam_policy_document" "kms_key_access" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      type        = "AWS"
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow access for Key Administrators"
+    effect = "Allow"
+    principals {
+      identifiers = data.aws_iam_roles.admins.arns
+      type        = "AWS"
+    }
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow use of the key"
+    effect = "Allow"
+    principals {
+      identifiers = concat(tolist(data.aws_iam_roles.admins.arns), [module.passport.iam_role_arn])
+      type        = "AWS"
+    }
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetPublicKey",
+      "kms:Sign",
+      "kms:Verify",
+      "kms:Encrypt",
+      "kms:Decrypt",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow attachment of persistent resources"
+    effect = "Allow"
+    principals {
+      identifiers = data.aws_iam_roles.admins.arns
+      type        = "AWS"
+    }
+    actions = [
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "Bool"
+      values   = ["true"]
+      variable = "kms:GrantIsForAWSResource"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_roles" "admins" {
+  name_regex = ".*-admin"
+}

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -1,0 +1,64 @@
+resource "aws_ssm_parameter" "passport_tls_key" {
+  name        = "/${var.environment}/cri/passport/tls-key"
+  description = "The TLS key used by the passport CRI"
+  type        = "SecureString"
+  value       = "" # Will be set by hand
+  overwrite   = false
+}
+
+resource "aws_ssm_parameter" "passport_tls_cert" {
+  name        = "/${var.environment}/cri/passport/tls-cert"
+  description = "The TLS certificate used by the passport CRI"
+  type        = "String"
+  value       = "" # Will be set by hand after a cert has been issued
+  overwrite   = false
+}
+
+resource "aws_ssm_parameter" "passport_signing_cert" {
+  name        = "/${var.environment}/cri/passport/signing-cert"
+  description = "The signing certificate used by the passport CRI"
+  type        = "String"
+  value       = "" # Will be set by hand after a cert has been issued
+  overwrite   = false
+}
+
+resource "aws_ssm_parameter" "passport_encryption_cert" {
+  name        = "/${var.environment}/cri/passport/signing-cert"
+  description = "The encryption certificate used by the passport CRI"
+  type        = "String"
+  value       = "" # Will be set by hand after a cert has been issued
+  overwrite   = false
+}
+
+resource "aws_ssm_parameter" "dcs_encryption_cert" {
+  name        = "/${var.environment}/dcs/encryption-cert"
+  description = "The DCS's public encryption cert"
+  type        = "String"
+  value       = "" # Will be set by hand
+  overwrite   = false
+}
+
+resource "aws_iam_role_policy" "get-parameters" {
+  name = "get-parameters"
+  role = module.passport.iam_role_id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "GetParameters"
+        Action = [
+          "ssm:GetParameter"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_ssm_parameter.passport_tls_key.arn,
+          aws_ssm_parameter.passport_tls_cert.arn,
+          aws_ssm_parameter.passport_signing_cert.arn,
+          aws_ssm_parameter.passport_encryption_cert.arn,
+          aws_ssm_parameter.dcs_encryption_cert.arn
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -11,13 +11,20 @@ module "passport" {
   function_name          = "${var.environment}-passport"
   role_name              = "${var.environment}-passport-role"
 
-
-  dcs_integration_encryption_cert_param = "/${var.environment}/dcs/integration-encryption-cert"
-  dcs_encryption_cert_param             = "/${var.environment}/cri/passport/alpha-dcs-encryption-cert"
-  dcs_encryption_key_param              = "/${var.environment}/cri/passport/alpha-dcs-encryption-key"
-  dcs_signing_cert_param                = "/${var.environment}/cri/passport/alpha-dcs-signing-cert"
-  dcs_signing_key_param                 = "/${var.environment}/cri/passport/alpha-dcs-signing-key"
-  dcs_tls_cert_param                    = "/${var.environment}/cri/passport/alpha-dcs-tls-cert"
-  dcs_tls_key_param                     = "/${var.environment}/cri/passport/alpha-dcs-tls-key"
+  env_vars = {
+    "DCS_ENCRYPTION_CERT_PARAM"                = aws_ssm_parameter.dcs_encryption_cert.name
+    "PASSPORT_CRI_ENCRYPTION_CERT_PARAM"       = "/${var.environment}/cri/passport/alpha-dcs-encryption-cert"
+    "PASSPORT_CRI_ENCRYPTION_KEY_PARAM"        = "/${var.environment}/cri/passport/alpha-dcs-encryption-key"
+    "PASSPORT_CRI_SIGNING_CERT_PARAM"          = "/${var.environment}/cri/passport/alpha-dcs-signing-cert"
+    "PASSPORT_CRI_SIGNING_KEY_PARAM"           = "/${var.environment}/cri/passport/alpha-dcs-signing-key"
+    "PASSPORT_CRI_TLS_CERT_PARAM"              = "/${var.environment}/cri/passport/alpha-dcs-tls-cert"
+    "PASSPORT_CRI_TLS_KEY_PARAM"               = "/${var.environment}/cri/passport/alpha-dcs-tls-key"
+    "PASSPORT_CRI_KMS_SIGNING_KEY_ID_PARAM"    = aws_kms_key.signing.id,
+    "PASSPORT_CRI_KMS_ENCRYPTION_KEY_ID_PARAM" = aws_kms_key.encryption.id,
+    "PASSPORT_CRI_KMS_SIGNING_CERT_PARAM"      = aws_ssm_parameter.passport_signing_cert.name
+    "PASSPORT_CRI_KMS_ENCRYPTION_CERT_PARAM"   = aws_ssm_parameter.passport_encryption_cert.name
+    "PASSPORT_CRI_TLS_KEY_PARAM"               = aws_ssm_parameter.passport_tls_key.name
+    "PASSPORT_CRI_TLS_CERT_PARAM"              = aws_ssm_parameter.passport_tls_cert.name
+  }
 }
 

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -19,17 +19,8 @@ resource "aws_lambda_function" "lambda_function" {
   timeout          = 30
   memory_size      = 2048
 
-
   environment {
-    variables = {
-      DCS_INTEGRATION_ENCRYPTION_CERT_PARAM = var.dcs_integration_encryption_cert_param
-      DCS_ENCRYPTION_CERT_PARAM             = var.dcs_encryption_cert_param
-      DCS_ENCRYPTION_KEY_PARAM              = var.dcs_encryption_key_param
-      DCS_SIGNING_CERT_PARAM                = var.dcs_signing_cert_param
-      DCS_SIGNING_KEY_PARAM                 = var.dcs_signing_key_param
-      DCS_TLS_CERT_PARAM                    = var.dcs_tls_cert_param
-      DCS_TLS_KEY_PARAM                     = var.dcs_tls_key_param
-    }
+    variables = var.env_vars
   }
 
   # There is an outstanding bug in terraform (Issue #3630) that means it always tries to update the

--- a/terraform/modules/endpoint/outputs.tf
+++ b/terraform/modules/endpoint/outputs.tf
@@ -7,3 +7,8 @@ output "iam_role_id" {
   description = "The ID of the IAM role used by the lambda"
   value       = aws_iam_role.lambda_iam_role.id
 }
+
+output "iam_role_arn" {
+  description = "The ARN of the IAM role used by the lambda"
+  value       = aws_iam_role.lambda_iam_role.arn
+}

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -42,39 +42,10 @@ variable "role_name" {
   description = "Lambda iam role name"
 }
 
-variable "dcs_integration_encryption_cert_param" {
-  type        = string
-  description = "DCS Integration Encryption Certificate Parameter Name"
-}
-
-variable "dcs_encryption_cert_param" {
-  type        = string
-  description = "DCS Encryption Certificate Parameter Name"
-}
-
-variable "dcs_encryption_key_param" {
-  type        = string
-  description = "DCS Encryption Key Parameter Name"
-}
-
-variable "dcs_signing_cert_param" {
-  type        = string
-  description = "DCS Signing Certificate Parameter Name"
-}
-
-variable "dcs_signing_key_param" {
-  type        = string
-  description = "DCS Signing Key Parameter Name"
-}
-
-variable "dcs_tls_cert_param" {
-  type        = string
-  description = "DCS TLS Certificate Parameter Name"
-}
-
-variable "dcs_tls_key_param" {
-  type        = string
-  description = "DCS TLS Key Parameter Name"
+variable "env_vars" {
+  type        = map
+  description = "env vars for the lambda"
+  default     = {}
 }
 
 locals {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Some terraform to create signing and encryption asymmetric key pairs for
use by the passport CRI with DCS. It provides the key IDs to the lambda as
env variables.

We've decided to hold fire on using KMS for a TLS key until we've
learnt a bit more.

It also changes the way we provide the env vars to the lambda, passing
a map into the module rather than declaring the variables.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-465](https://govukverify.atlassian.net/browse/PYI-465)
