### PR TITLE
BAU: Add missing JsonProperty annotation 

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
@@ -8,8 +8,8 @@ import java.time.LocalDate;
 
 public class DcsCheckRequestDto {
 
-    private static final String dateFormat = "yyyy-MM-dd";
-    private static final String timeZone = "UTC";
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private static final String TIME_ZONE = "UTC";
 
     @JsonProperty private final String passportNumber;
 
@@ -18,10 +18,10 @@ public class DcsCheckRequestDto {
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     private final String[] forenames;
 
-    @JsonFormat(pattern = dateFormat, timezone = timeZone)
+    @JsonFormat(pattern = DATE_FORMAT, timezone = TIME_ZONE)
     private final LocalDate dateOfBirth;
 
-    @JsonFormat(pattern = dateFormat, timezone = timeZone)
+    @JsonFormat(pattern = DATE_FORMAT, timezone = TIME_ZONE)
     private final LocalDate expiryDate;
 
     @JsonCreator

--- a/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/dto/DcsCheckRequestDto.java
@@ -11,8 +11,9 @@ public class DcsCheckRequestDto {
     private static final String dateFormat = "yyyy-MM-dd";
     private static final String timeZone = "UTC";
 
-    private final String passportNumber;
-    private final String surname;
+    @JsonProperty private final String passportNumber;
+
+    @JsonProperty private final String surname;
 
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     private final String[] forenames;


### PR DESCRIPTION
to fix missing fields when using the… ObjectMapper to create json string

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add @JsonProperty annotation to the dto fields.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To fix the issue that these fields are currently skipped when using the ObjectMapper to write the object as a JSON string.
<!-- Describe the reason these changes were made - the "why" -->
