### PR TITLE
PYI-465: Give parameters real values

### DIFF
--- a/terraform/lambda/kms.tf
+++ b/terraform/lambda/kms.tf
@@ -109,8 +109,6 @@ data "aws_iam_policy_document" "kms_key_access" {
   }
 }
 
-data "aws_caller_identity" "current" {}
-
 data "aws_iam_roles" "admins" {
   name_regex = ".*-admin"
 }

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -1,41 +1,29 @@
-resource "aws_ssm_parameter" "passport_tls_key" {
-  name        = "/${var.environment}/cri/passport/tls-key"
-  description = "The TLS key used by the passport CRI"
-  type        = "SecureString"
-  value       = "" # Will be set by hand
-  overwrite   = false
-}
-
 resource "aws_ssm_parameter" "passport_tls_cert" {
   name        = "/${var.environment}/cri/passport/tls-cert"
   description = "The TLS certificate used by the passport CRI"
   type        = "String"
-  value       = "" # Will be set by hand after a cert has been issued
-  overwrite   = false
+  value       = var.passport_tls_cert
 }
 
 resource "aws_ssm_parameter" "passport_signing_cert" {
   name        = "/${var.environment}/cri/passport/signing-cert"
   description = "The signing certificate used by the passport CRI"
   type        = "String"
-  value       = "" # Will be set by hand after a cert has been issued
-  overwrite   = false
+  value       = var.passport_signing_cert
 }
 
 resource "aws_ssm_parameter" "passport_encryption_cert" {
-  name        = "/${var.environment}/cri/passport/signing-cert"
+  name        = "/${var.environment}/cri/passport/encryption-cert"
   description = "The encryption certificate used by the passport CRI"
   type        = "String"
-  value       = "" # Will be set by hand after a cert has been issued
-  overwrite   = false
+  value       = var.passport_encryption_cert
 }
 
 resource "aws_ssm_parameter" "dcs_encryption_cert" {
   name        = "/${var.environment}/dcs/encryption-cert"
   description = "The DCS's public encryption cert"
   type        = "String"
-  value       = "" # Will be set by hand
-  overwrite   = false
+  value       = var.dcs_encryption_cert
 }
 
 resource "aws_iam_role_policy" "get-parameters" {
@@ -52,7 +40,7 @@ resource "aws_iam_role_policy" "get-parameters" {
         ]
         Effect = "Allow"
         Resource = [
-          aws_ssm_parameter.passport_tls_key.arn,
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/dev/cri/passport/tls-key",
           aws_ssm_parameter.passport_tls_cert.arn,
           aws_ssm_parameter.passport_signing_cert.arn,
           aws_ssm_parameter.passport_encryption_cert.arn,

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -21,9 +21,9 @@ module "passport" {
     "PASSPORT_CRI_TLS_KEY_PARAM"               = "/${var.environment}/cri/passport/alpha-dcs-tls-key"
     "PASSPORT_CRI_KMS_SIGNING_KEY_ID_PARAM"    = aws_kms_key.signing.id,
     "PASSPORT_CRI_KMS_ENCRYPTION_KEY_ID_PARAM" = aws_kms_key.encryption.id,
+    "PASSPORT_CRI_TLS_KEY_PARAM"               = "/${var.environment}/cri/passport/tls-key"
     "PASSPORT_CRI_KMS_SIGNING_CERT_PARAM"      = aws_ssm_parameter.passport_signing_cert.name
     "PASSPORT_CRI_KMS_ENCRYPTION_CERT_PARAM"   = aws_ssm_parameter.passport_encryption_cert.name
-    "PASSPORT_CRI_TLS_KEY_PARAM"               = aws_ssm_parameter.passport_tls_key.name
     "PASSPORT_CRI_TLS_CERT_PARAM"              = aws_ssm_parameter.passport_tls_cert.name
   }
 }

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -7,9 +7,20 @@ variable "use_localstack" {
   default = false
 }
 
+variable "passport_tls_cert" { type = string }
+
+variable "passport_signing_cert" { type = string }
+
+variable "passport_encryption_cert" { type = string }
+
+variable "dcs_encryption_cert" { type = string }
+
 locals {
   default_tags = var.use_localstack ? null : {
     Environment = var.environment
     Source      = "github.com/alphagov/di-ipv-cri-uk-passport-back/terraform/lambda"
   }
 }
+
+data "aws_caller_identity" "current" {}
+


### PR DESCRIPTION
**See the accompanying PR here: https://github.com/alphagov/di-ipv-config/pull/70**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The previous approach of using dummy data for the parameter values which
we'll update outside of terraform won't work. Terraform will just try to
overwrite it the next time it's applied. Setting the `overwrite` flag to
false didn't do what I'd expected it to. Instead it just throws an
error.

This change uses values for the certs passed in from the terraform
project root in `di-ipv-config` for the non-secure parameters. We'll
need to manage the "SecureString" parameters completely outside of
Terraform as we can't pass the secret values in in the same way.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-465](https://govukverify.atlassian.net/browse/PYI-465)

