### PR TITLE
PYI-470: Add terraform resources for auth-codes, access-tokens and protected resources dynamodb tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 `di-ipv-cri-uk-passport-back`
 
 This the back-end code for the UK Passport Credential Issuer(CRI) for the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.
+
+## Environment variables
+
+* IS_LOCAL - This only needs to be assigned when running locally. This is set to `true` in `local-startup`.
+### DynamoDB table name variables:
+Each environment has a specific table name prefix e.g. `dev-{dynamo-table-name}`
+
+These values are automatically assigned by terraform within the `aws_lambda_function` resource
+* ACCESS_TOKENS_TABLE_NAME
+* AUTH_CODES_TABLE_NAME
+* CRI_PASSPORT_CREDENTIALS_TABLE_NAME

--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -1,0 +1,120 @@
+resource "aws_dynamodb_table" "cri-passport-credentials" {
+  name         = "${var.environment}-cri-passport-credentials"
+  hash_key     = "ipvSessionId"
+  range_key    = "requestId"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "ipvSessionId"
+    type = "S"
+  }
+
+  attribute {
+    name = "requestId"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_dynamodb_table" "cri-passport-auth-codes" {
+  name         = "${var.environment}-cri-passport-auth-codes"
+  hash_key     = "authCode"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "authCode"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_dynamodb_table" "cri-passport-access-tokens" {
+  name         = "${var.environment}-cri-passport-access-tokens"
+  hash_key     = "accessToken"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "accessToken"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_policy" "policy-cri-passport-credentials-table" {
+  name = "policy-cri-passport-credentials-table"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "PolicyCriPassportCredentialsTable"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Scan",
+          "dynamodb:Query",
+          "dynamodb:ConditionCheckItem"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.cri-passport-credentials.arn,
+          "${aws_dynamodb_table.cri-passport-credentials.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "policy-cri-passport-auth-codes-table" {
+  name = "policy-cri-passport-auth-codes-table"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "PolicyCriPassportAuthCodesTable"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.cri-passport-auth-codes.arn,
+          "${aws_dynamodb_table.cri-passport-auth-codes.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "policy-cri-passport-access-tokens-table" {
+  name = "policy-cri-passport-access-tokens-table"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "PolicyCriPassportAccessTokensTable"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.cri-passport-access-tokens.arn,
+          "${aws_dynamodb_table.cri-passport-access-tokens.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -11,6 +11,12 @@ module "passport" {
   function_name          = "${var.environment}-passport"
   role_name              = "${var.environment}-passport-role"
 
+  allow_access_to_cri_passport_auth_codes_table = true
+  cri_passport_auth_codes_table_policy_arn      = aws_iam_policy.policy-cri-passport-auth-codes-table.arn
+
+  allow_access_to_cri_passport_credentials_table = true
+  cri_passport_credentials_table_policy_arn      = aws_iam_policy.policy-cri-passport-credentials-table.arn
+
   env_vars = {
     "DCS_ENCRYPTION_CERT_PARAM"                = aws_ssm_parameter.dcs_encryption_cert.name
     "PASSPORT_CRI_SIGNING_KEY_PARAM"           = "/${var.environment}/cri/passport/signing-key"
@@ -19,6 +25,9 @@ module "passport" {
     "PASSPORT_CRI_SIGNING_CERT_PARAM"          = aws_ssm_parameter.passport_signing_cert.name
     "PASSPORT_CRI_ENCRYPTION_CERT_PARAM"       = aws_ssm_parameter.passport_encryption_cert.name
     "PASSPORT_CRI_TLS_CERT_PARAM"              = aws_ssm_parameter.passport_tls_cert.name
+    CRI_PASSPORT_CREDENTIALS_TABLE_NAME        = aws_dynamodb_table.cri-passport-credentials.name
+    AUTH_CODES_TABLE_NAME                      = aws_dynamodb_table.cri-passport-auth-codes.name
+    ACCESS_TOKENS_TABLE_NAME                   = aws_dynamodb_table.cri-passport-access-tokens.name
   }
 }
 

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -23,3 +23,21 @@ resource "aws_iam_role" "lambda_iam_role" {
 
   tags = local.default_tags
 }
+
+resource "aws_iam_role_policy_attachment" "cri_passport_credentials_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_cri_passport_credentials_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.cri_passport_credentials_table_policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "auth_codes_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_cri_passport_auth_codes_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.cri_passport_auth_codes_table_policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "tokens_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_cri_passport_access_tokens_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.cri_passport_access_tokens_table_policy_arn
+}

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -48,6 +48,42 @@ variable "env_vars" {
   default     = {}
 }
 
+variable "allow_access_to_cri_passport_credentials_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the cri-passport-credentials DynamoDB table"
+}
+
+variable "cri_passport_credentials_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the cri-passport-credentials DynamoDB table"
+}
+
+variable "allow_access_to_cri_passport_auth_codes_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the cri-passport-auth-codes DynamoDB table"
+}
+
+variable "cri_passport_auth_codes_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the cri-passport-auth-codes DynamoDB table"
+}
+
+variable "allow_access_to_cri_passport_access_tokens_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the cri-passport-access-tokens DynamoDB table"
+}
+
+variable "cri_passport_access_tokens_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the cri-passport-access-tokens DynamoDB table"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add terraform resources for dynamoDB tables:
- cri-passport-auth-codes
- cri-passport-access-tokens
- cri-passport-credentials

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To create the required aws DynamoDB resources for storing auth-codes/access-tokens/credentials
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-470](https://govukverify.atlassian.net/browse/PYI-470)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks
