### PR TITLE
PYI-471: Create DataStore class to read/write/delete to DynamoDB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
 			"org.slf4j:slf4j-simple:1.7.32",
+			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
 			"software.amazon.lambda:powertools-parameters:1.8.0",
 			"com.google.code.gson:gson:2.8.9",
 			"com.nimbusds:nimbus-jose-jwt:9.15.2"

--- a/src/main/java/uk/gov/di/ipv/cri/passport/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/persistence/DataStore.java
@@ -1,0 +1,96 @@
+package uk.gov.di.ipv.cri.passport.persistence;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.ipv.cri.passport.service.ConfigurationService;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DataStore<T> {
+
+    private static final String LOCALHOST_URI = "http://localhost:4567";
+
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final String tableName;
+    private final Class<T> typeParameterClass;
+
+    public DataStore(
+            String tableName,
+            Class<T> typeParameterClass,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+        this.tableName = tableName;
+        this.typeParameterClass = typeParameterClass;
+        this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
+    }
+
+    public static DynamoDbEnhancedClient getClient() {
+        DynamoDbClient client =
+                new ConfigurationService().isRunningLocally()
+                        ? createLocalDbClient()
+                        : DynamoDbClient.create();
+
+        return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
+    }
+
+    public void create(T item) {
+        getTable().putItem(item);
+    }
+
+    public T getItem(String partitionValue, String sortValue) {
+        return getItemByKey(
+                Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+    }
+
+    public T getItem(String partitionValue) {
+        return getItemByKey(Key.builder().partitionValue(partitionValue).build());
+    }
+
+    public List<T> getItems(String partitionValue) {
+        return getTable()
+                .query(
+                        QueryConditional.keyEqualTo(
+                                Key.builder().partitionValue(partitionValue).build()))
+                .stream()
+                .flatMap(page -> page.items().stream())
+                .collect(Collectors.toList());
+    }
+
+    public T update(T item) {
+        return getTable().updateItem(item);
+    }
+
+    public T delete(String partitionValue, String sortValue) {
+        return delete(Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+    }
+
+    public T delete(String partitionValue) {
+        return delete(Key.builder().partitionValue(partitionValue).build());
+    }
+
+    private static DynamoDbClient createLocalDbClient() {
+        return DynamoDbClient.builder()
+                .endpointOverride(URI.create(LOCALHOST_URI))
+                .region(Region.EU_WEST_2)
+                .build();
+    }
+
+    private T getItemByKey(Key key) {
+        return getTable().getItem(key);
+    }
+
+    private T delete(Key key) {
+        return getTable().deleteItem(key);
+    }
+
+    private DynamoDbTable<T> getTable() {
+        return dynamoDbEnhancedClient.table(
+                tableName, TableSchema.fromBean(this.typeParameterClass));
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/AuthorizationCodeItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/AuthorizationCodeItem.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.passport.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AuthorizationCodeItem {
+
+    private String authCode;
+    private String resourceId;
+
+    @DynamoDbPartitionKey
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceIdId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/persistance/DataStoreTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/persistance/DataStoreTest.java
@@ -1,0 +1,147 @@
+package uk.gov.di.ipv.cri.passport.persistance;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.AuthorizationCodeItem;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DataStoreTest {
+    private static final String TEST_TABLE_NAME = "test-auth-code-table";
+
+    private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
+    private DynamoDbTable<AuthorizationCodeItem> mockDynamoDbTable;
+
+    private AuthorizationCodeItem authorizationCodeItem;
+    private DataStore<AuthorizationCodeItem> dataStore;
+
+    @BeforeEach
+    void setUp() {
+        mockDynamoDbEnhancedClient = mock(DynamoDbEnhancedClient.class);
+        mockDynamoDbTable = mock(DynamoDbTable.class);
+
+        when(mockDynamoDbEnhancedClient.table(anyString(), any(TableSchema.class)))
+                .thenReturn(mockDynamoDbTable);
+
+        authorizationCodeItem = new AuthorizationCodeItem();
+        authorizationCodeItem.setAuthCode(new AuthorizationCode().getValue());
+        authorizationCodeItem.setResourceIdId("test-resource-12345");
+
+        dataStore =
+                new DataStore<>(
+                        TEST_TABLE_NAME, AuthorizationCodeItem.class, mockDynamoDbEnhancedClient);
+    }
+
+    @Test
+    void shouldPutItemIntoDynamoDbTable() {
+        dataStore.create(authorizationCodeItem);
+
+        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
+                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).putItem(authorizationCodeItemArgumentCaptor.capture());
+        assertEquals(
+                authorizationCodeItem.getAuthCode(),
+                authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
+        assertEquals(
+                authorizationCodeItem.getResourceId(),
+                authorizationCodeItemArgumentCaptor.getValue().getResourceId());
+    }
+
+    @Test
+    void shouldGetItemFromDynamoDbTableViaPartitionKeyAndSortKey() {
+        dataStore.getItem("partition-key-12345", "sort-key-12345");
+
+        ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).getItem(keyCaptor.capture());
+        assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
+        assertEquals("sort-key-12345", keyCaptor.getValue().sortKeyValue().get().s());
+    }
+
+    @Test
+    void shouldGetItemFromDynamoDbTableViaPartitionKey() {
+        dataStore.getItem("partition-key-12345");
+
+        ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).getItem(keyCaptor.capture());
+        assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
+        assertTrue(keyCaptor.getValue().sortKeyValue().isEmpty());
+    }
+
+    @Test
+    void shouldGetItemsFromDynamoDbTableViaPartitionKeyQueryRequest() {
+        PageIterable<AuthorizationCodeItem> mockPageIterable = mock(PageIterable.class);
+
+        when(mockDynamoDbTable.query(any(QueryConditional.class))).thenReturn(mockPageIterable);
+        when(mockPageIterable.stream()).thenReturn(Stream.empty());
+
+        dataStore.getItems("partition-key-12345");
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).query(any(QueryConditional.class));
+    }
+
+    @Test
+    void shouldUpdateItemInDynamoDbTable() {
+        dataStore.update(authorizationCodeItem);
+
+        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
+                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).updateItem(authorizationCodeItemArgumentCaptor.capture());
+        assertEquals(
+                authorizationCodeItem.getAuthCode(),
+                authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
+        assertEquals(
+                authorizationCodeItem.getResourceId(),
+                authorizationCodeItemArgumentCaptor.getValue().getResourceId());
+    }
+
+    @Test
+    void shouldDeleteItemFromDynamoDbTableViaPartitionKeyAndSortKey() {
+        dataStore.delete("partition-key-12345", "sort-key-12345");
+
+        ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).deleteItem(keyCaptor.capture());
+        assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
+        assertEquals("sort-key-12345", keyCaptor.getValue().sortKeyValue().get().s());
+    }
+
+    @Test
+    void shouldDeleteItemFromDynamoDbTableViaPartitionKey() {
+        dataStore.delete("partition-key-12345");
+
+        ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
+
+        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), any(TableSchema.class));
+        verify(mockDynamoDbTable).deleteItem(keyCaptor.capture());
+        assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
+        assertTrue(keyCaptor.getValue().sortKeyValue().isEmpty());
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Created new DataStore class to handle the read/write/delete to DynamoDB.
Created AuthorisationCodeItem class.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The class will be used to handle all read/write/deletes to the DB for authcodes, access tokens and DCS resources.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-471](https://govukverify.atlassian.net/browse/PYI-471)

