### PR TITLE
PYI-472: Persist the dcs response into the dcs-response DynamoDB table

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -65,6 +65,8 @@ public class PassportHandler
             String jsonPayload = objectMapper.writeValueAsString(dcsPayload);
             String response = passportService.dcsPassportCheck(jsonPayload);
 
+            passportService.persistDcsResponse(response);
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
 
         } catch (IOException e) {

--- a/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/DcsResponseItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/DcsResponseItem.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.passport.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class DcsResponseItem {
+
+    private String resourceId;
+    private String resourcePayload;
+
+    @DynamoDbPartitionKey
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getResourcePayload() {
+        return resourcePayload;
+    }
+
+    public void setResourcePayload(String resourcePayload) {
+        this.resourcePayload = resourcePayload;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
@@ -54,6 +54,10 @@ public class ConfigurationService {
         return Boolean.parseBoolean(System.getenv(IS_LOCAL));
     }
 
+    public String getDcsResponseTableName() {
+        return System.getenv("DCS_RESPONSE_TABLE_NAME");
+    }
+
     private String getParameterFromStoreUsingEnv(String environmentVariable) {
         return ssmProvider.get(System.getenv(environmentVariable));
     }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
@@ -6,29 +6,35 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import uk.gov.di.ipv.cri.passport.helpers.HttpClientSetUp;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.UUID;
 
 public class PassportService {
 
     private final ConfigurationService configurationService;
     private final DcsSigningService dcsSigningService;
     private final DcsEncryptionService dcsEncryptionService;
+    private final DataStore<DcsResponseItem> dataStore;
     private final HttpClient httpClient;
 
     public PassportService(
             HttpClient httpClient,
             ConfigurationService configurationService,
             DcsEncryptionService dcsEncryptionService,
-            DcsSigningService dcsSigningService) {
+            DcsSigningService dcsSigningService,
+            DataStore<DcsResponseItem> dataStore) {
         this.httpClient = httpClient;
         this.configurationService = configurationService;
         this.dcsEncryptionService = dcsEncryptionService;
         this.dcsSigningService = dcsSigningService;
+        this.dataStore = dataStore;
     }
 
     public PassportService()
@@ -37,6 +43,11 @@ public class PassportService {
         this.configurationService = new ConfigurationService();
         this.dcsSigningService = new DcsSigningService();
         this.dcsEncryptionService = new DcsEncryptionService();
+        this.dataStore =
+                new DataStore<>(
+                        configurationService.getDcsResponseTableName(),
+                        DcsResponseItem.class,
+                        DataStore.getClient());
         this.httpClient = HttpClientSetUp.generateHttpClient(configurationService);
     }
 
@@ -55,10 +66,17 @@ public class PassportService {
             if ((response != null)) {
                 return response.toString();
             }
-
         } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
+    }
+
+    public void persistDcsResponse(String responsePayload) {
+        DcsResponseItem dcsResponseItem = new DcsResponseItem();
+        dcsResponseItem.setResourceId(UUID.randomUUID().toString());
+        dcsResponseItem.setResourcePayload(responsePayload);
+
+        dataStore.create(dcsResponseItem);
     }
 }

--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -1,16 +1,10 @@
-resource "aws_dynamodb_table" "cri-passport-credentials" {
-  name         = "${var.environment}-cri-passport-credentials"
-  hash_key     = "ipvSessionId"
-  range_key    = "requestId"
+resource "aws_dynamodb_table" "dcs-response" {
+  name         = "${var.environment}-dcs-response"
+  hash_key     = "resourceId"
   billing_mode = "PAY_PER_REQUEST"
 
   attribute {
-    name = "ipvSessionId"
-    type = "S"
-  }
-
-  attribute {
-    name = "requestId"
+    name = "resourceId"
     type = "S"
   }
 
@@ -43,14 +37,14 @@ resource "aws_dynamodb_table" "cri-passport-access-tokens" {
   tags = local.default_tags
 }
 
-resource "aws_iam_policy" "policy-cri-passport-credentials-table" {
-  name = "policy-cri-passport-credentials-table"
+resource "aws_iam_policy" "policy-dcs-response-table" {
+  name = "policy-dcs-response-table"
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid = "PolicyCriPassportCredentialsTable"
+        Sid = "PolicyDcsResponseTable"
         Action = [
           "dynamodb:PutItem",
           "dynamodb:UpdateItem",
@@ -63,8 +57,8 @@ resource "aws_iam_policy" "policy-cri-passport-credentials-table" {
         ]
         Effect = "Allow"
         Resource = [
-          aws_dynamodb_table.cri-passport-credentials.arn,
-          "${aws_dynamodb_table.cri-passport-credentials.arn}/index/*"
+          aws_dynamodb_table.dcs-response.arn,
+          "${aws_dynamodb_table.dcs-response.arn}/index/*"
         ]
       },
     ]

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -14,8 +14,8 @@ module "passport" {
   allow_access_to_cri_passport_auth_codes_table = true
   cri_passport_auth_codes_table_policy_arn      = aws_iam_policy.policy-cri-passport-auth-codes-table.arn
 
-  allow_access_to_cri_passport_credentials_table = true
-  cri_passport_credentials_table_policy_arn      = aws_iam_policy.policy-cri-passport-credentials-table.arn
+  allow_access_to_dcs_response_table            = true
+  dcs_response_table_policy_arn                 = aws_iam_policy.policy-dcs-response-table.arn
 
   env_vars = {
     "DCS_ENCRYPTION_CERT_PARAM"                = "/${var.environment}/dcs/encryption-cert"
@@ -28,7 +28,7 @@ module "passport" {
     "DCS_POST_URL_PARAM"                       = "/${var.environment}/dcs/post-url"
     "DCS_TLS_ROOT_CERT_PARAM"                  = "/${var.environment}/dcs/tls-root-certificate"
     "DCS_TLS_INTERMEDIATE_CERT_PARAM"          = "/${var.environment}/dcs/tls-intermediate-certificate"
-    "CRI_PASSPORT_CREDENTIALS_TABLE_NAME"      = aws_dynamodb_table.cri-passport-credentials.name
+    "DCS_RESPONSE_TABLE_NAME"                  = aws_dynamodb_table.dcs-response.name
     "AUTH_CODES_TABLE_NAME"                    = aws_dynamodb_table.cri-passport-auth-codes.name
     "ACCESS_TOKENS_TABLE_NAME"                 = aws_dynamodb_table.cri-passport-access-tokens.name
   }

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -25,9 +25,9 @@ resource "aws_iam_role" "lambda_iam_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "cri_passport_credentials_table_policy_to_lambda_iam_role" {
-  count      = var.allow_access_to_cri_passport_credentials_table ? 1 : 0
+  count      = var.allow_access_to_dcs_response_table ? 1 : 0
   role       = aws_iam_role.lambda_iam_role.name
-  policy_arn = var.cri_passport_credentials_table_policy_arn
+  policy_arn = var.dcs_response_table_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "auth_codes_table_policy_to_lambda_iam_role" {

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -48,16 +48,16 @@ variable "env_vars" {
   default     = {}
 }
 
-variable "allow_access_to_cri_passport_credentials_table" {
+variable "allow_access_to_dcs_response_table" {
   type        = bool
   default     = false
-  description = "Should the lambda be given access to the cri-passport-credentials DynamoDB table"
+  description = "Should the lambda be given access to the dcs-response DynamoDB table"
 }
 
-variable "cri_passport_credentials_table_policy_arn" {
+variable "dcs_response_table_policy_arn" {
   type        = string
   default     = null
-  description = "ARN of the policy to allow read write to the cri-passport-credentials DynamoDB table"
+  description = "ARN of the policy to allow read write to the dcs-response DynamoDB table"
 }
 
 variable "allow_access_to_cri_passport_auth_codes_table" {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Created new DynamoDB DcsResponseItem class.
- Add new persistence method in the passportService to store the dcs response in the DB.
- Refactor the terraform dcs-response table names and env variables.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Need to store the response from DCS into dynamo that can then be later retrieved with an access token.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-472](https://govukverify.atlassian.net/browse/PYI-472)

