### PR TITLE
PYI-476: Add stub DCS lambda

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/annotations/ExcludeFromGeneratedCoverageReport.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/annotations/ExcludeFromGeneratedCoverageReport.java
@@ -6,5 +6,5 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.CONSTRUCTOR)
+@Target({ElementType.CONSTRUCTOR, ElementType.TYPE})
 public @interface ExcludeFromGeneratedCoverageReport {}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsResponse.java
@@ -1,0 +1,48 @@
+package uk.gov.di.ipv.cri.passport.domain;
+
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.UUID;
+
+@ExcludeFromGeneratedCoverageReport
+public class DcsResponse {
+
+    private final UUID correlationId;
+    private final UUID requestId;
+    private final boolean error;
+    private final boolean valid;
+    private final String[] errorMessage;
+
+    public DcsResponse(
+            UUID correlationId,
+            UUID requestId,
+            boolean error,
+            boolean valid,
+            String[] errorMessage) {
+        this.correlationId = correlationId;
+        this.requestId = requestId;
+        this.error = error;
+        this.valid = valid;
+        this.errorMessage = errorMessage;
+    }
+
+    public UUID getCorrelationId() {
+        return correlationId;
+    }
+
+    public UUID getRequestId() {
+        return requestId;
+    }
+
+    public boolean getError() {
+        return error;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String[] getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
@@ -1,0 +1,130 @@
+package uk.gov.di.ipv.cri.passport.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.gson.Gson;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.domain.ProtectedHeader;
+import uk.gov.di.ipv.cri.passport.domain.Thumbprints;
+import uk.gov.di.ipv.cri.passport.exceptions.IpvCryptoException;
+import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.cri.passport.service.ConfigurationService;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
+import java.util.UUID;
+
+@ExcludeFromGeneratedCoverageReport
+public class StubDcsHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    static {
+        // Set the default synchronous HTTP client to UrlConnectionHttpClient
+        System.setProperty(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StubDcsHandler.class);
+    private static final Gson gson = new Gson();
+    private static final ConfigurationService configService = new ConfigurationService();
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+
+        DcsResponse dcsResponse =
+                new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
+        LOGGER.info(
+                "Generated DCS response with correlationId: {} and requestId: {}",
+                dcsResponse.getCorrelationId(),
+                dcsResponse.getRequestId());
+
+        try {
+            var signedPayload = sign(gson.toJson(dcsResponse));
+            var encryptedPayload = encrypt(signedPayload);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_OK, sign(encryptedPayload));
+        } catch (NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException
+                | CertificateException e) {
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    private String sign(String stringToSign)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
+                    JOSEException {
+        Certificate stubDcsSigningCertificate = configService.getStubDcsSigningCert();
+        Thumbprints thumbprints =
+                new Thumbprints(
+                        configService.getThumbprint(
+                                (X509Certificate) stubDcsSigningCertificate, "SHA-1"),
+                        configService.getThumbprint(
+                                (X509Certificate) stubDcsSigningCertificate, "SHA-256"));
+
+        ProtectedHeader protectedHeader =
+                new ProtectedHeader(
+                        JWSAlgorithm.RS256.toString(),
+                        thumbprints.getSha1Thumbprint(),
+                        thumbprints.getSha256Thumbprint());
+
+        String jsonHeaders = gson.toJson(protectedHeader);
+
+        JWSObject jwsObject =
+                new JWSObject(
+                        new JWSHeader.Builder(JWSAlgorithm.RS256)
+                                .customParams(gson.fromJson(jsonHeaders, Map.class))
+                                .build(),
+                        new Payload(stringToSign));
+
+        jwsObject.sign(new RSASSASigner((RSAPrivateKey) configService.getStubDcsSigningKey()));
+
+        return jwsObject.serialize();
+    }
+
+    private String encrypt(String stringToEncrypt) throws CertificateException, JOSEException {
+        var header =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A128CBC_HS256)
+                        .type(new JOSEObjectType("JWE"))
+                        .build();
+        var jwe = new JWEObject(header, new Payload(stringToEncrypt));
+
+        jwe.encrypt(
+                new RSAEncrypter(
+                        (RSAPublicKey)
+                                configService.getPassportCriEncryptionCert().getPublicKey()));
+
+        if (!jwe.getState().equals(JWEObject.State.ENCRYPTED)) {
+            throw new IpvCryptoException("Something went wrong, couldn't encrypt JWE");
+        }
+
+        return jwe.serialize();
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
@@ -89,6 +89,10 @@ public class ConfigurationService {
         return getKeyFromStoreUsingEnv("PASSPORT_CRI_ENCRYPTION_KEY_PARAM");
     }
 
+    public Certificate getPassportCriEncryptionCert() throws CertificateException {
+        return getCertificateFromStoreUsingEnv("PASSPORT_CRI_ENCRYPTION_CERT_PARAM");
+    }
+
     public Key getPassportCriSigningKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
         return getKeyFromStoreUsingEnv("PASSPORT_CRI_SIGNING_KEY_PARAM");
     }
@@ -110,6 +114,14 @@ public class ConfigurationService {
             getCertificateFromStoreUsingEnv("DCS_TLS_ROOT_CERT_PARAM"),
             getCertificateFromStoreUsingEnv("DCS_TLS_INTERMEDIATE_CERT_PARAM")
         };
+    }
+
+    public Certificate getStubDcsSigningCert() throws CertificateException {
+        return getCertificateFromStoreUsingEnv("STUB_DCS_SIGNING_CERT_PARAM");
+    }
+
+    public Key getStubDcsSigningKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return getKeyFromStoreUsingEnv("STUB_DCS_SIGNING_KEY_PARAM");
     }
 
     public String getDCSPostUrl() {

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -71,6 +71,14 @@ resource "aws_ssm_parameter" "local_only_passport_signing_key" {
   value       = var.local_only_passport_signing_key
 }
 
+resource "aws_ssm_parameter" "local_only_passport_tls_key" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/cri/passport/tls-key"
+  description = "The tls key used by the passport CRI when running in local stack."
+  type        = "SecureString"
+  value       = var.local_only_passport_tls_key
+}
+
 resource "aws_iam_role_policy" "get-parameters" {
   name = "get-parameters"
   role = module.passport.iam_role_id

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -44,7 +44,31 @@ resource "aws_ssm_parameter" "dcs_post_url" {
   name        = "/${var.environment}/dcs/post-url"
   description = "The DCS's url for passport valid check"
   type        = "String"
-  value       = var.dcs_post_url
+  value       = var.use_localstack ? "http://localhost:4567/restapis/${aws_api_gateway_rest_api.ipv_cri_uk_passport.id}/local-dev/_user_request_/stub-dcs-check-passport" : var.dcs_post_url
+}
+
+resource "aws_ssm_parameter" "stub_dcs_signing_cert" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/stub-dcs/signing-cert"
+  description = "The signing certificate used by the stub DCS"
+  type        = "String"
+  value       = var.stub_dcs_signing_cert
+}
+
+resource "aws_ssm_parameter" "stub_dcs_signing_key" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/stub-dcs/signing-key"
+  description = "The signing key used by the stub DCS"
+  type        = "SecureString"
+  value       = var.stub_dcs_signing_key
+}
+
+resource "aws_ssm_parameter" "local_only_passport_signing_key" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/cri/passport/signing-key"
+  description = "The signing key used by the passport CRI when running in local stack."
+  type        = "SecureString"
+  value       = var.local_only_passport_signing_key
 }
 
 resource "aws_iam_role_policy" "get-parameters" {

--- a/terraform/lambda/stub-dcs.tf
+++ b/terraform/lambda/stub-dcs.tf
@@ -1,0 +1,21 @@
+module "stub-dcs" {
+  count      = var.use_localstack ? 1 : 0
+  source      = "../modules/endpoint"
+  environment = var.environment
+
+  rest_api_id            = aws_api_gateway_rest_api.ipv_cri_uk_passport.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.ipv_cri_uk_passport.execution_arn
+  root_resource_id       = aws_api_gateway_rest_api.ipv_cri_uk_passport.root_resource_id
+  http_method            = "POST"
+  path_part              = "stub-dcs-check-passport"
+  handler                = "uk.gov.di.ipv.cri.passport.lambda.StubDcsHandler::handleRequest"
+  function_name          = "${var.environment}-stub-dcs"
+  role_name              = "${var.environment}-stub-dcs-role"
+
+  env_vars = {
+    "STUB_DCS_SIGNING_CERT_PARAM"        = aws_ssm_parameter.stub_dcs_signing_cert[0].name
+    "STUB_DCS_SIGNING_KEY_PARAM"         = aws_ssm_parameter.stub_dcs_signing_key[0].name
+    "PASSPORT_CRI_ENCRYPTION_CERT_PARAM" = aws_ssm_parameter.passport_encryption_cert.name
+  }
+}
+

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -19,7 +19,25 @@ variable "dcs_tls_intermediate_cert" { type = string }
 
 variable "dcs_tls_root_cert" { type = string }
 
-variable "dcs_post_url" { type = string }
+variable "dcs_post_url" {
+  type    = string
+  default = ""
+}
+
+variable "stub_dcs_signing_cert" {
+  type    = string
+  default = ""
+}
+
+variable "stub_dcs_signing_key" {
+  type    = string
+  default = ""
+}
+
+variable "local_only_passport_signing_key" {
+  type    = string
+  default = ""
+}
 
 locals {
   default_tags = var.use_localstack ? null : {

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -38,6 +38,10 @@ variable "local_only_passport_signing_key" {
   type    = string
   default = ""
 }
+variable "local_only_passport_tls_key" {
+  type    = string
+  default = ""
+}
 
 locals {
   default_tags = var.use_localstack ? null : {


### PR DESCRIPTION
**See the companion PR that invokes this new terraform here: https://github.com/alphagov/di-ipv-local-startup/pull/18**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a lambda that will only be deployed locally. It's a stub for
DCS.

Currently it ignores the incoming payload and generates a valid response
with new UUIDs.

When we've finished the work in the passport CRI to verify and decrypt
response from the DCS, we can steal the logic to unwrap incoming
payloads to the stub DCS and use the UUIDs contained in the response.

It will use dev PKI that is passed in from the terraform project root in
local-startup. It goes without saying that this PKI should never be used
for anything else.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-476](https://govukverify.atlassian.net/browse/PYI-476)
