### PR TITLE
PYI-462: Generate and return an oauth auth-code on passport validation request

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorResponse {
-    FAILED_TO_PARSE_PASSPORT_FORM_DATA(1000, "Failed to parse passport form data");
+    FAILED_TO_PARSE_PASSPORT_FORM_DATA(1000, "Failed to parse passport form data"),
+    MISSING_QUERY_PARAMETERS(1001, "Missing query parameters for auth request"),
+    FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(
+            1002, "Failed to parse oauth2-specific query string parameters");
 
     private final int code;
     private final String message;

--- a/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/AuthorizationCodeItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/AuthorizationCodeItem.java
@@ -22,7 +22,7 @@ public class AuthorizationCodeItem {
         return resourceId;
     }
 
-    public void setResourceIdId(String resourceId) {
+    public void setResourceId(String resourceId) {
         this.resourceId = resourceId;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/AuthorizationCodeService.java
@@ -1,0 +1,50 @@
+package uk.gov.di.ipv.cri.passport.service;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.AuthorizationCodeItem;
+
+import java.util.Objects;
+
+public class AuthorizationCodeService {
+    private final DataStore<AuthorizationCodeItem> dataStore;
+    private final ConfigurationService configurationService;
+
+    @ExcludeFromGeneratedCoverageReport
+    public AuthorizationCodeService() {
+        this.configurationService = new ConfigurationService();
+        this.dataStore =
+                new DataStore<>(
+                        configurationService.getAuthCodesTableName(),
+                        AuthorizationCodeItem.class,
+                        DataStore.getClient());
+    }
+
+    public AuthorizationCodeService(
+            DataStore<AuthorizationCodeItem> dataStore, ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.dataStore = dataStore;
+    }
+
+    public AuthorizationCode generateAuthorizationCode() {
+        return new AuthorizationCode();
+    }
+
+    public String getResourceIdByAuthorizationCode(String authorizationCode) {
+        AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
+        return Objects.isNull(authorizationCodeItem) ? null : authorizationCodeItem.getResourceId();
+    }
+
+    public void persistAuthorizationCode(String authorizationCode, String resourceId) {
+        AuthorizationCodeItem authorizationCodeItem = new AuthorizationCodeItem();
+        authorizationCodeItem.setAuthCode(authorizationCode);
+        authorizationCodeItem.setResourceId(resourceId);
+
+        dataStore.create(authorizationCodeItem);
+    }
+
+    public void revokeAuthorizationCode(String authorizationCode) {
+        dataStore.delete(authorizationCode);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
@@ -58,6 +58,10 @@ public class ConfigurationService {
         return System.getenv("DCS_RESPONSE_TABLE_NAME");
     }
 
+    public String getAuthCodesTableName() {
+        return System.getenv("CRI_PASSPORT_AUTH_CODES_TABLE_NAME");
+    }
+
     private String getParameterFromStoreUsingEnv(String environmentVariable) {
         return ssmProvider.get(System.getenv(environmentVariable));
     }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
@@ -72,11 +72,12 @@ public class PassportService {
         return null;
     }
 
-    public void persistDcsResponse(String responsePayload) {
+    public DcsResponseItem persistDcsResponse(String responsePayload) {
         DcsResponseItem dcsResponseItem = new DcsResponseItem();
         dcsResponseItem.setResourceId(UUID.randomUUID().toString());
         dcsResponseItem.setResourcePayload(responsePayload);
 
         dataStore.create(dcsResponseItem);
+        return dcsResponseItem;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/validation/ValidationResult.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/validation/ValidationResult.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.cri.passport.validation;
+
+public class ValidationResult<T> {
+    private final boolean valid;
+    private final T error;
+
+    public ValidationResult(boolean valid, T error) {
+        this.valid = valid;
+        this.error = error;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public T getError() {
+        return error;
+    }
+
+    public static <U> ValidationResult<U> createValidResult() {
+        return new ValidationResult<>(true, null);
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/OAuth2RequestParams.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/OAuth2RequestParams.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.cri.passport.lambda;
+
+class OAuth2RequestParams {
+    static final String REDIRECT_URI = "redirect_uri";
+    static final String CLIENT_ID = "client_id";
+    static final String RESPONSE_TYPE = "response_type";
+    static final String SCOPE = "scope";
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandlerTest.java
@@ -2,9 +2,11 @@ package uk.gov.di.ipv.cri.passport.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,11 +15,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
+import uk.gov.di.ipv.cri.passport.service.AuthorizationCodeService;
 import uk.gov.di.ipv.cri.passport.service.PassportService;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,18 +44,37 @@ class PassportHandlerTest {
 
     @Mock Context context;
     @Mock PassportService passportService;
+    @Mock AuthorizationCodeService authorizationCodeService;
 
     private PassportHandler underTest;
+    private AuthorizationCode authorizationCode;
 
     @BeforeEach
     void setUp() {
-        underTest = new PassportHandler(passportService);
+        authorizationCode = new AuthorizationCode();
+
+        underTest = new PassportHandler(passportService, authorizationCodeService);
     }
 
     @Test
     void shouldReturn200WithCorrectFormData() throws IOException {
-        when(passportService.dcsPassportCheck(any(String.class))).thenReturn("Response");
+        String dcsResponse = "test dcs response";
+        when(passportService.dcsPassportCheck(any(String.class))).thenReturn(dcsResponse);
+
+        DcsResponseItem testDcsResponseItem = new DcsResponseItem();
+        testDcsResponseItem.setResourcePayload(dcsResponse);
+        testDcsResponseItem.setResourceId(UUID.randomUUID().toString());
+        when(passportService.persistDcsResponse(dcsResponse)).thenReturn(testDcsResponseItem);
+
+        when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
+
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         var response = underTest.handleRequest(event, context);
@@ -59,10 +83,162 @@ class PassportHandlerTest {
     }
 
     @Test
+    void shouldReturnAuthResponseOnSuccessfulOauthRequest() throws IOException {
+        String dcsResponse = "test dcs response";
+        when(passportService.dcsPassportCheck(any(String.class))).thenReturn(dcsResponse);
+
+        DcsResponseItem testDcsResponseItem = new DcsResponseItem();
+        testDcsResponseItem.setResourcePayload(dcsResponse);
+        testDcsResponseItem.setResourceId(UUID.randomUUID().toString());
+        when(passportService.persistDcsResponse(dcsResponse)).thenReturn(testDcsResponseItem);
+
+        when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
+
+        var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        Map<String, String> authCode = (Map) responseBody.get("code");
+
+        verify(authorizationCodeService)
+                .persistAuthorizationCode(
+                        authCode.get("value"), testDcsResponseItem.getResourceId());
+        assertEquals(authorizationCode.toString(), authCode.get("value"));
+    }
+
+    @Test
+    void shouldReturn400OnMissingRedirectUriParam() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
+                responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400OnMissingClientIdParam() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
+                responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400OnMissingResponseTypeParam() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
+                responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400OnMissingScopeParam() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
+                responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400OnMissingQueryParameters() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
     void shouldReturn400IfDataIsMissing() throws JsonProcessingException {
         var formFields = validPassportFormData.keySet();
         for (String keyToRemove : formFields) {
             var event = new APIGatewayProxyRequestEvent();
+            Map<String, String> params = new HashMap<>();
+            params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+            params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+            params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+            params.put(OAuth2RequestParams.SCOPE, "openid");
+            event.setQueryStringParameters(params);
             event.setBody(
                     objectMapper.writeValueAsString(
                             new HashMap<>(validPassportFormData).remove(keyToRemove)));
@@ -86,6 +262,12 @@ class PassportHandlerTest {
         mangledDateInput.put("dateOfBirth", "28-09-1984");
 
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
         event.setBody(objectMapper.writeValueAsString(mangledDateInput));
 
         var response = underTest.handleRequest(event, context);
@@ -104,7 +286,21 @@ class PassportHandlerTest {
     void shouldPersistDcsResponse() throws IOException {
         String dcsResponse = "test dcs response payload";
         when(passportService.dcsPassportCheck(any(String.class))).thenReturn(dcsResponse);
+
+        DcsResponseItem testDcsResponseItem = new DcsResponseItem();
+        testDcsResponseItem.setResourcePayload(dcsResponse);
+        testDcsResponseItem.setResourceId(UUID.randomUUID().toString());
+        when(passportService.persistDcsResponse(dcsResponse)).thenReturn(testDcsResponseItem);
+
+        when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
+
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         underTest.handleRequest(event, context);
@@ -113,5 +309,38 @@ class PassportHandlerTest {
         verify(passportService).persistDcsResponse(responseArgumentCaptor.capture());
 
         assertEquals(dcsResponse, responseArgumentCaptor.getValue());
+    }
+
+    @Test
+    void shouldPersistAuthCode() throws IOException {
+        String dcsResponse = "test dcs response payload";
+        when(passportService.dcsPassportCheck(any(String.class))).thenReturn(dcsResponse);
+
+        DcsResponseItem testDcsResponseItem = new DcsResponseItem();
+        testDcsResponseItem.setResourcePayload(dcsResponse);
+        testDcsResponseItem.setResourceId(UUID.randomUUID().toString());
+        when(passportService.persistDcsResponse(dcsResponse)).thenReturn(testDcsResponseItem);
+
+        when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
+
+        var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
+        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
+        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
+        params.put(OAuth2RequestParams.SCOPE, "openid");
+        event.setQueryStringParameters(params);
+        event.setBody(objectMapper.writeValueAsString(validPassportFormData));
+
+        underTest.handleRequest(event, context);
+
+        ArgumentCaptor<String> authCodeArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> resourceIdArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(authorizationCodeService)
+                .persistAuthorizationCode(
+                        authCodeArgumentCaptor.capture(), resourceIdArgumentCaptor.capture());
+
+        assertEquals(authorizationCode.toString(), authCodeArgumentCaptor.getValue());
+        assertEquals(testDcsResponseItem.getResourceId(), resourceIdArgumentCaptor.getValue());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/passport/persistance/DataStoreTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/persistance/DataStoreTest.java
@@ -43,7 +43,7 @@ class DataStoreTest {
 
         authorizationCodeItem = new AuthorizationCodeItem();
         authorizationCodeItem.setAuthCode(new AuthorizationCode().getValue());
-        authorizationCodeItem.setResourceIdId("test-resource-12345");
+        authorizationCodeItem.setResourceId("test-resource-12345");
 
         dataStore =
                 new DataStore<>(

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/AuthorizationCodeServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/AuthorizationCodeServiceTest.java
@@ -1,0 +1,93 @@
+package uk.gov.di.ipv.cri.passport.service;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.AuthorizationCodeItem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthorizationCodeServiceTest {
+
+    private DataStore<AuthorizationCodeItem> mockDataStore;
+    private ConfigurationService mockConfigurationService;
+
+    private AuthorizationCodeService authorizationCodeService;
+
+    @BeforeEach
+    void setUp() {
+        mockDataStore = mock(DataStore.class);
+        mockConfigurationService = mock(ConfigurationService.class);
+        when(mockConfigurationService.getAuthCodesTableName()).thenReturn("test-auth-code-table");
+
+        authorizationCodeService =
+                new AuthorizationCodeService(mockDataStore, mockConfigurationService);
+    }
+
+    @Test
+    void shouldReturnAnAuthorisationCode() {
+        AuthorizationCode result = authorizationCodeService.generateAuthorizationCode();
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldCreateAuthorizationCodeInDataStore() {
+        AuthorizationCode testCode = new AuthorizationCode();
+        String resourceId = "resource-12345";
+        authorizationCodeService.persistAuthorizationCode(testCode.getValue(), resourceId);
+
+        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
+                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
+        verify(mockDataStore).create(authorizationCodeItemArgumentCaptor.capture());
+        assertEquals(resourceId, authorizationCodeItemArgumentCaptor.getValue().getResourceId());
+        assertEquals(
+                testCode.getValue(), authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
+    }
+
+    @Test
+    void shouldGetResourceIdByAuthCodeWhenValidAuthCodeProvided() {
+        AuthorizationCode testCode = new AuthorizationCode();
+        String resourceId = "resource-12345";
+
+        AuthorizationCodeItem testItem = new AuthorizationCodeItem();
+        testItem.setResourceId(resourceId);
+
+        when(mockDataStore.getItem(testCode.getValue())).thenReturn(testItem);
+
+        String resultResourceId =
+                authorizationCodeService.getResourceIdByAuthorizationCode(testCode.getValue());
+
+        verify(mockDataStore).getItem(testCode.getValue());
+        assertEquals(resourceId, resultResourceId);
+    }
+
+    @Test
+    void shouldReturnNullWhenInvalidAuthCodeProvided() {
+        AuthorizationCode testCode = new AuthorizationCode();
+
+        when(mockDataStore.getItem(testCode.getValue())).thenReturn(null);
+
+        String resultResourceId =
+                authorizationCodeService.getResourceIdByAuthorizationCode(testCode.getValue());
+
+        verify(mockDataStore).getItem(testCode.getValue());
+        assertNull(resultResourceId);
+    }
+
+    @Test
+    void shouldCallDeleteWithAuthCode() {
+        AuthorizationCode testCode = new AuthorizationCode();
+
+        authorizationCodeService.revokeAuthorizationCode(testCode.getValue());
+
+        verify(mockDataStore).delete(testCode.getValue());
+    }
+}

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -29,8 +29,8 @@ module "passport" {
     "DCS_TLS_ROOT_CERT_PARAM"                  = "/${var.environment}/dcs/tls-root-certificate"
     "DCS_TLS_INTERMEDIATE_CERT_PARAM"          = "/${var.environment}/dcs/tls-intermediate-certificate"
     "DCS_RESPONSE_TABLE_NAME"                  = aws_dynamodb_table.dcs-response.name
-    "AUTH_CODES_TABLE_NAME"                    = aws_dynamodb_table.cri-passport-auth-codes.name
-    "ACCESS_TOKENS_TABLE_NAME"                 = aws_dynamodb_table.cri-passport-access-tokens.name
+    "CRI_PASSPORT_AUTH_CODES_TABLE_NAME"                    = aws_dynamodb_table.cri-passport-auth-codes.name
+    "CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME"                 = aws_dynamodb_table.cri-passport-access-tokens.name
   }
 }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Read and validate the required oauth query parameters from incoming request into lambda.
- Generate an authorisation code and store it within DynamoDB linked to the DCS resource via resourceId field.
- Return the auth-code back to cri-passport-front.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Auth code will be needed for the cri-passport oauth flow in order to control access to the protected resource.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-462](https://govukverify.atlassian.net/browse/PYI-462)

