### PR TITLE
Pyi 480

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelper.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.cri.passport.helpers;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class RequestHelper {
+
+    public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+
+    private RequestHelper() {}
+
+    public static String getHeaderByKey(Map<String, String> headers, String headerKey) {
+        if (Objects.isNull(headers)) {
+            return null;
+        }
+        var values =
+                headers.entrySet().stream()
+                        .filter(e -> headerKey.equalsIgnoreCase(e.getKey()))
+                        .map(Map.Entry::getValue)
+                        .collect(Collectors.toList());
+        if (values.size() == 1) {
+            var value = values.get(0);
+            if (StringUtils.isNotBlank(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelper.java
@@ -8,8 +8,6 @@ import java.util.stream.Collectors;
 
 public class RequestHelper {
 
-    public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
-
     private RequestHelper() {}
 
     public static String getHeaderByKey(Map<String, String> headers, String headerKey) {

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandler.java
@@ -4,11 +4,29 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.cri.passport.helpers.RequestHelper;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
+import uk.gov.di.ipv.cri.passport.service.AccessTokenService;
+import uk.gov.di.ipv.cri.passport.service.DcsCredentialService;
 
 public class DcsCredentialHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DcsCredentialHandler.class);
+    private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
+
+    private final DcsCredentialService dcsCredentialService;
+    private final AccessTokenService accessTokenService;
+
     static {
         // Set the default synchronous HTTP client to UrlConnectionHttpClient
         System.setProperty(
@@ -16,9 +34,48 @@ public class DcsCredentialHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    public DcsCredentialHandler(
+            DcsCredentialService dcsCredentialService, AccessTokenService accessTokenService) {
+        this.dcsCredentialService = dcsCredentialService;
+        this.accessTokenService = accessTokenService;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    public DcsCredentialHandler() {
+        this.dcsCredentialService = new DcsCredentialService();
+        this.accessTokenService = new AccessTokenService();
+    }
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, "Hello world");
+        try {
+            String accessTokenString =
+                    RequestHelper.getHeaderByKey(input.getHeaders(), AUTHORIZATION_HEADER_KEY);
+
+            // Performs validation on header value and throws a ParseException if invalid
+            AccessToken.parse(accessTokenString);
+
+            String resourceId = accessTokenService.getResourceIdByAccessToken(accessTokenString);
+
+            if (StringUtils.isBlank(resourceId)) {
+                LOGGER.error(
+                        "User credential could not be retrieved. The supplied access token was not found in the database.");
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        OAuth2Error.ACCESS_DENIED.getHTTPStatusCode(),
+                        OAuth2Error.ACCESS_DENIED
+                                .appendDescription(
+                                        " - The supplied access token was not found in the database")
+                                .toJSONObject());
+            }
+
+            DcsResponseItem credential = dcsCredentialService.getDcsCredential(resourceId);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, credential);
+        } catch (ParseException e) {
+            LOGGER.error("Failed to parse access token");
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());
+        }
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialService.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.cri.passport.service;
+
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
+
+public class DcsCredentialService {
+    private final ConfigurationService configurationService;
+    private final DataStore<DcsResponseItem> dataStore;
+
+    @ExcludeFromGeneratedCoverageReport
+    public DcsCredentialService() {
+        this.configurationService = new ConfigurationService();
+        this.dataStore =
+                new DataStore<>(
+                        configurationService.getDcsResponseTableName(),
+                        DcsResponseItem.class,
+                        DataStore.getClient());
+    }
+
+    public DcsCredentialService(
+            ConfigurationService configurationService, DataStore<DcsResponseItem> dataStore) {
+        this.configurationService = configurationService;
+        this.dataStore = dataStore;
+    }
+
+    public DcsResponseItem getDcsCredential(String resourceId) {
+        return dataStore.getItem(resourceId);
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/helpers/RequestHelperTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.cri.passport.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RequestHelperTest {
+
+    Map<String, String> headers =
+            Map.of(
+                    "foo", "bar",
+                    "Foo", "bar",
+                    "baz", "bar");
+
+    @Test
+    void getHeaderByKeyShouldReturnHeaderIfMatchFound() {
+        assertEquals("toyou", RequestHelper.getHeaderByKey(Map.of("tome", "toyou"), "tome"));
+    }
+
+    @Test
+    void getHeaderByKeyShouldReturnNullIfHeaderNotFound() {
+        assertNull(RequestHelper.getHeaderByKey(Map.of("tome", "toyou"), "ohdearohdear"));
+    }
+
+    @Test
+    void getHeaderByKeyShouldReturnNullIfNoHeadersProvided() {
+        assertNull(RequestHelper.getHeaderByKey(null, "ohdearohdear"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/AccessTokenHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/AccessTokenHandlerTest.java
@@ -30,7 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AccessTokenHandlerTest {
+class AccessTokenHandlerTest {
 
     private static final String TEST_RESOURCE_ID = UUID.randomUUID().toString();
 

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandlerTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -53,7 +52,8 @@ class DcsCredentialHandlerTest {
         dcsCredential.setResourceId("12345");
         dcsCredential.setResourcePayload("Test dcs resource payload");
 
-        dcsCredentialHandler = new DcsCredentialHandler(mockDcsCredentialService, mockAccessTokenService);
+        dcsCredentialHandler =
+                new DcsCredentialHandler(mockDcsCredentialService, mockAccessTokenService);
     }
 
     @Test
@@ -66,10 +66,10 @@ class DcsCredentialHandlerTest {
 
         when(mockAccessTokenService.getResourceIdByAccessToken(anyString()))
                 .thenReturn(TEST_RESOURCE_ID);
-        when(mockDcsCredentialService.getDcsCredential(anyString()))
-                .thenReturn(dcsCredential);
+        when(mockDcsCredentialService.getDcsCredential(anyString())).thenReturn(dcsCredential);
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
 
         assertEquals(200, response.getStatusCode());
     }
@@ -84,10 +84,10 @@ class DcsCredentialHandlerTest {
 
         when(mockAccessTokenService.getResourceIdByAccessToken(anyString()))
                 .thenReturn(TEST_RESOURCE_ID);
-        when(mockDcsCredentialService.getDcsCredential(anyString()))
-                .thenReturn(dcsCredential);
+        when(mockDcsCredentialService.getDcsCredential(anyString())).thenReturn(dcsCredential);
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
         Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(dcsCredential.getResourceId(), responseBody.get("resourceId"));
@@ -100,7 +100,8 @@ class DcsCredentialHandlerTest {
         Map<String, String> headers = Collections.singletonMap("Authorization", null);
         event.setHeaders(headers);
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
         responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(BearerTokenError.MISSING_TOKEN.getHTTPStatusCode(), response.getStatusCode());
@@ -116,7 +117,8 @@ class DcsCredentialHandlerTest {
         Map<String, String> headers = Collections.singletonMap("Authorization", "11111111");
         event.setHeaders(headers);
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
         responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(
@@ -131,7 +133,8 @@ class DcsCredentialHandlerTest {
     void shouldReturnErrorResponseWhenTokenIsMissing() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
         responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(BearerTokenError.MISSING_TOKEN.getHTTPStatusCode(), response.getStatusCode());
@@ -151,7 +154,8 @@ class DcsCredentialHandlerTest {
 
         when(mockAccessTokenService.getResourceIdByAccessToken(anyString())).thenReturn(null);
 
-        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        APIGatewayProxyResponseEvent response =
+                dcsCredentialHandler.handleRequest(event, mockContext);
         Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(403, response.getStatusCode());

--- a/src/test/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/lambda/DcsCredentialHandlerTest.java
@@ -1,0 +1,166 @@
+package uk.gov.di.ipv.cri.passport.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
+import uk.gov.di.ipv.cri.passport.service.AccessTokenService;
+import uk.gov.di.ipv.cri.passport.service.DcsCredentialService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DcsCredentialHandlerTest {
+
+    private static final String TEST_RESOURCE_ID = UUID.randomUUID().toString();
+
+    @Mock private Context mockContext;
+
+    @Mock private DcsCredentialService mockDcsCredentialService;
+
+    @Mock private AccessTokenService mockAccessTokenService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private DcsCredentialHandler dcsCredentialHandler;
+    private DcsResponseItem dcsCredential;
+    private Map<String, String> responseBody;
+
+    @BeforeEach
+    void setUp() {
+        dcsCredential = new DcsResponseItem();
+        responseBody = new HashMap<>();
+
+        dcsCredential.setResourceId("12345");
+        dcsCredential.setResourcePayload("Test dcs resource payload");
+
+        dcsCredentialHandler = new DcsCredentialHandler(mockDcsCredentialService, mockAccessTokenService);
+    }
+
+    @Test
+    void shouldReturn200OnSuccessfulDcsCredentialRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        Map<String, String> headers =
+                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+        event.setHeaders(headers);
+
+        when(mockAccessTokenService.getResourceIdByAccessToken(anyString()))
+                .thenReturn(TEST_RESOURCE_ID);
+        when(mockDcsCredentialService.getDcsCredential(anyString()))
+                .thenReturn(dcsCredential);
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnCredentialsOnSuccessfulDcsCredentialRequest() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        Map<String, String> headers =
+                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+        event.setHeaders(headers);
+
+        when(mockAccessTokenService.getResourceIdByAccessToken(anyString()))
+                .thenReturn(TEST_RESOURCE_ID);
+        when(mockDcsCredentialService.getDcsCredential(anyString()))
+                .thenReturn(dcsCredential);
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(dcsCredential.getResourceId(), responseBody.get("resourceId"));
+        assertEquals(dcsCredential.getResourcePayload(), responseBody.get("resourcePayload"));
+    }
+
+    @Test
+    void shouldReturnErrorResponseWhenTokenIsNull() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> headers = Collections.singletonMap("Authorization", null);
+        event.setHeaders(headers);
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(BearerTokenError.MISSING_TOKEN.getHTTPStatusCode(), response.getStatusCode());
+        assertEquals(BearerTokenError.MISSING_TOKEN.getCode(), responseBody.get("error"));
+        assertEquals(
+                BearerTokenError.MISSING_TOKEN.getDescription(),
+                responseBody.get("error_description"));
+    }
+
+    @Test
+    void shouldReturnErrorResponseWhenTokenIsMissingBearerPrefix() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> headers = Collections.singletonMap("Authorization", "11111111");
+        event.setHeaders(headers);
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(
+                BearerTokenError.INVALID_REQUEST.getHTTPStatusCode(), response.getStatusCode());
+        assertEquals(BearerTokenError.INVALID_REQUEST.getCode(), responseBody.get("error"));
+        assertEquals(
+                BearerTokenError.INVALID_REQUEST.getDescription(),
+                responseBody.get("error_description"));
+    }
+
+    @Test
+    void shouldReturnErrorResponseWhenTokenIsMissing() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(BearerTokenError.MISSING_TOKEN.getHTTPStatusCode(), response.getStatusCode());
+        assertEquals(BearerTokenError.MISSING_TOKEN.getCode(), responseBody.get("error"));
+        assertEquals(
+                BearerTokenError.MISSING_TOKEN.getDescription(),
+                responseBody.get("error_description"));
+    }
+
+    @Test
+    void shouldReturnErrorResponseWhenInvalidAccessTokenProvided() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        Map<String, String> headers =
+                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+        event.setHeaders(headers);
+
+        when(mockAccessTokenService.getResourceIdByAccessToken(anyString())).thenReturn(null);
+
+        APIGatewayProxyResponseEvent response = dcsCredentialHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(403, response.getStatusCode());
+        assertEquals(OAuth2Error.ACCESS_DENIED.getCode(), responseBody.get("error"));
+        assertEquals(
+                OAuth2Error.ACCESS_DENIED
+                        .appendDescription(
+                                " - The supplied access token was not found in the database")
+                        .getDescription(),
+                responseBody.get("error_description"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/AccessTokenServiceTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AccessTokenServiceTest {
+class AccessTokenServiceTest {
     private DataStore<AccessTokenItem> mockDataStore;
     private ConfigurationService mockConfigurationService;
     private AccessTokenService accessTokenService;

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialServiceTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.ipv.cri.passport.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.persistence.item.DcsResponseItem;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DcsCredentialServiceTest {
+
+    @Mock private ConfigurationService mockConfigurationService;
+
+    @Mock private DataStore<DcsResponseItem> mockDataStore;
+
+    private DcsCredentialService dcsCredentialService;
+
+    @BeforeEach
+    void setUp() {
+        dcsCredentialService = new DcsCredentialService(mockConfigurationService, mockDataStore);
+    }
+
+    @Test
+    void shouldReturnCredentialsFromDataStore() {
+        DcsResponseItem dcsCredential = new DcsResponseItem();
+        dcsCredential.setResourceId(UUID.randomUUID().toString());
+        dcsCredential.setResourcePayload("test dcs resource payload");
+
+        when(mockDataStore.getItem(anyString())).thenReturn(dcsCredential);
+
+        DcsResponseItem credential =
+                dcsCredentialService.getDcsCredential("dcs-credential-id-1");
+
+        assertEquals(dcsCredential.getResourceId(), credential.getResourceId());
+        assertEquals(dcsCredential.getResourceId(), credential.getResourcePayload());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCredentialServiceTest.java
@@ -36,10 +36,9 @@ class DcsCredentialServiceTest {
 
         when(mockDataStore.getItem(anyString())).thenReturn(dcsCredential);
 
-        DcsResponseItem credential =
-                dcsCredentialService.getDcsCredential("dcs-credential-id-1");
+        DcsResponseItem credential = dcsCredentialService.getDcsCredential("dcs-credential-id-1");
 
         assertEquals(dcsCredential.getResourceId(), credential.getResourceId());
-        assertEquals(dcsCredential.getResourceId(), credential.getResourcePayload());
+        assertEquals(dcsCredential.getResourcePayload(), credential.getResourcePayload());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update DCSResponse lambda to validate the requests access token and exchange it for the DCS Credential.
Fix sonar code smells on tests
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This will allow the access tokens generated from the other lambda to be used to retrieve a protected DCS credential from the DB.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-480](https://govukverify.atlassian.net/browse/PYI-480)

