### PR TITLE
PYI-476: Verify/decrypt payload in stub DCS

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsPayload.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsPayload.java
@@ -14,11 +14,19 @@ public class DcsPayload {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String TIME_ZONE = "UTC";
 
-    @JsonProperty public final UUID correlationId;
-    @JsonProperty public final UUID requestId;
-    @JsonProperty public final String timestamp;
-    @JsonProperty public final String passportNumber;
-    @JsonProperty public final String surname;
+    public UUID getCorrelationId() {
+        return correlationId;
+    }
+
+    public UUID getRequestId() {
+        return requestId;
+    }
+
+    @JsonProperty private final UUID correlationId;
+    @JsonProperty private final UUID requestId;
+    @JsonProperty private final String timestamp;
+    @JsonProperty private final String passportNumber;
+    @JsonProperty private final String surname;
 
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     public final String[] forenames;

--- a/src/main/java/uk/gov/di/ipv/cri/passport/exceptions/StubDcsException.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/exceptions/StubDcsException.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.cri.passport.exceptions;
+
+import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class StubDcsException extends Exception {
+    public StubDcsException(String message) {
+        super(message);
+    }
+
+    public StubDcsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
@@ -15,28 +16,33 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.RSAEncrypter;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.domain.ProtectedHeader;
 import uk.gov.di.ipv.cri.passport.domain.Thumbprints;
-import uk.gov.di.ipv.cri.passport.exceptions.IpvCryptoException;
+import uk.gov.di.ipv.cri.passport.exceptions.StubDcsException;
 import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.cri.passport.serialization.LocalDateDeserializer;
 import uk.gov.di.ipv.cri.passport.service.ConfigurationService;
 
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.Map;
-import java.util.UUID;
 
 @ExcludeFromGeneratedCoverageReport
 public class StubDcsHandler
@@ -50,44 +56,95 @@ public class StubDcsHandler
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StubDcsHandler.class);
-    private static final Gson gson = new Gson();
+    private static final Gson gson =
+            new GsonBuilder()
+                    .registerTypeAdapter(LocalDate.class, new LocalDateDeserializer())
+                    .create();
     private static final ConfigurationService configService = new ConfigurationService();
+    private static final RSASSAVerifier verifier = getPassportCriVerifier();
+    private static final RSAEncrypter encrypter = getPassportCriEncrypter();
+    private static final RSASSASigner signer = getStubDcsSigner();
+    private static final RSADecrypter decrypter = getStubDcsDecrypter();
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
 
-        DcsResponse dcsResponse =
-                new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
-        LOGGER.info(
-                "Generated DCS response with correlationId: {} and requestId: {}",
-                dcsResponse.getCorrelationId(),
-                dcsResponse.getRequestId());
-
         try {
-            var signedPayload = sign(gson.toJson(dcsResponse));
-            var encryptedPayload = encrypt(signedPayload);
+            DcsPayload incomingPayload = verifyAndDecryptAndVerify(input.getBody());
+
+            DcsResponse dcsResponse =
+                    new DcsResponse(
+                            incomingPayload.getCorrelationId(),
+                            incomingPayload.getRequestId(),
+                            false,
+                            true,
+                            null);
+            LOGGER.info(
+                    "Generated DCS response with correlationId: {} and requestId: {}",
+                    dcsResponse.getCorrelationId(),
+                    dcsResponse.getRequestId());
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK, sign(encryptedPayload));
-        } catch (NoSuchAlgorithmException
-                | InvalidKeySpecException
-                | JOSEException
-                | CertificateException e) {
+                    HttpStatus.SC_OK, signAndEncryptAndSign(dcsResponse));
+
+        } catch (StubDcsException e) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, e);
         }
     }
 
-    private String sign(String stringToSign)
-            throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
-                    JOSEException {
-        Certificate stubDcsSigningCertificate = configService.getStubDcsSigningCert();
-        Thumbprints thumbprints =
-                new Thumbprints(
-                        configService.getThumbprint(
-                                (X509Certificate) stubDcsSigningCertificate, "SHA-1"),
-                        configService.getThumbprint(
-                                (X509Certificate) stubDcsSigningCertificate, "SHA-256"));
+    private String signAndEncryptAndSign(DcsResponse dcsResponse) throws StubDcsException {
+        return sign(encrypt(sign(gson.toJson(dcsResponse))));
+    }
+
+    private DcsPayload verifyAndDecryptAndVerify(String dcsPayloadString) throws StubDcsException {
+        JWSObject signedEncryptedSignedPayload;
+        try {
+            signedEncryptedSignedPayload = JWSObject.parse(dcsPayloadString);
+        } catch (ParseException e) {
+            throw new StubDcsException("Unable to parse DCS Payload to JWSObject", e);
+        }
+
+        try {
+            if (signatureNotValid(signedEncryptedSignedPayload)) {
+                throw new StubDcsException("Outer signature of DCS Payload not valid");
+            }
+        } catch (JOSEException e) {
+            throw new StubDcsException("Unable to verify outer signature of DCS Payload", e);
+        }
+
+        JWEObject encryptedSignedPayload;
+        try {
+            encryptedSignedPayload =
+                    JWEObject.parse(signedEncryptedSignedPayload.getPayload().toString());
+        } catch (ParseException e) {
+            throw new StubDcsException("Unable to parse encrypted payload", e);
+        }
+
+        JWSObject decryptedSignedPayload = decrypt(encryptedSignedPayload);
+        try {
+            decryptedSignedPayload.verify(verifier);
+        } catch (JOSEException e) {
+            throw new StubDcsException("Unable to verify inner signature of DCS Payload", e);
+        }
+
+        return gson.fromJson(decryptedSignedPayload.getPayload().toString(), DcsPayload.class);
+    }
+
+    private String sign(String stringToSign) throws StubDcsException {
+        Thumbprints thumbprints;
+        try {
+            Certificate stubDcsSigningCertificate = configService.getDcsSigningCert();
+            thumbprints =
+                    new Thumbprints(
+                            configService.getThumbprint(
+                                    (X509Certificate) stubDcsSigningCertificate, "SHA-1"),
+                            configService.getThumbprint(
+                                    (X509Certificate) stubDcsSigningCertificate, "SHA-256"));
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            throw new StubDcsException("Unable to generate thumbprints", e);
+        }
 
         ProtectedHeader protectedHeader =
                 new ProtectedHeader(
@@ -104,27 +161,82 @@ public class StubDcsHandler
                                 .build(),
                         new Payload(stringToSign));
 
-        jwsObject.sign(new RSASSASigner((RSAPrivateKey) configService.getStubDcsSigningKey()));
+        try {
+            jwsObject.sign(signer);
+        } catch (JOSEException e) {
+            throw new StubDcsException("Unable to sign DCS response", e);
+        }
 
         return jwsObject.serialize();
     }
 
-    private String encrypt(String stringToEncrypt) throws CertificateException, JOSEException {
+    private String encrypt(String stringToEncrypt) throws StubDcsException {
         var header =
                 new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A128CBC_HS256)
                         .type(new JOSEObjectType("JWE"))
                         .build();
         var jwe = new JWEObject(header, new Payload(stringToEncrypt));
 
-        jwe.encrypt(
-                new RSAEncrypter(
-                        (RSAPublicKey)
-                                configService.getPassportCriEncryptionCert().getPublicKey()));
+        try {
+            jwe.encrypt(encrypter);
+        } catch (JOSEException e) {
+            throw new StubDcsException("Something went wrong, couldn't encrypt JWE", e);
+        }
 
         if (!jwe.getState().equals(JWEObject.State.ENCRYPTED)) {
-            throw new IpvCryptoException("Something went wrong, couldn't encrypt JWE");
+            throw new StubDcsException(
+                    String.format(
+                            "Something went wrong, JWE not in encrypted state. State is: '%s'",
+                            jwe.getState()));
         }
 
         return jwe.serialize();
+    }
+
+    public JWSObject decrypt(JWEObject encrypted) throws StubDcsException {
+        try {
+            encrypted.decrypt(decrypter);
+            return JWSObject.parse(encrypted.getPayload().toString());
+        } catch (ParseException | JOSEException e) {
+            throw new StubDcsException("Cannot decrypt DCS payload", e);
+        }
+    }
+
+    private static RSADecrypter getStubDcsDecrypter() {
+        try {
+            return new RSADecrypter((PrivateKey) configService.getStubDcsEncryptionKey());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static RSASSASigner getStubDcsSigner() {
+        try {
+            return new RSASSASigner((PrivateKey) configService.getStubDcsSigningKey());
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static RSAEncrypter getPassportCriEncrypter() {
+        try {
+            return new RSAEncrypter(
+                    (RSAPublicKey) configService.getPassportCriEncryptionCert().getPublicKey());
+        } catch (CertificateException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static RSASSAVerifier getPassportCriVerifier() {
+        try {
+            return new RSASSAVerifier(
+                    (RSAPublicKey) configService.getPassportCriSigningCert().getPublicKey());
+        } catch (CertificateException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private boolean signatureNotValid(JWSObject toVerify) throws JOSEException {
+        return !toVerify.verify(verifier);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/serialization/LocalDateDeserializer.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/serialization/LocalDateDeserializer.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.cri.passport.serialization;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+
+public class LocalDateDeserializer implements JsonDeserializer<LocalDate> {
+
+    @Override
+    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        return LocalDate.parse(json.getAsString());
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
@@ -94,6 +94,10 @@ public class ConfigurationService {
         return factory.generatePrivate(privateKeySpec);
     }
 
+    public Certificate getDcsSigningCert() throws CertificateException {
+        return getCertificateFromStoreUsingEnv("DCS_SIGNING_CERT_PARAM");
+    }
+
     public Certificate getDcsEncryptionCert() throws CertificateException {
         return getCertificateFromStoreUsingEnv("DCS_ENCRYPTION_CERT_PARAM");
     }
@@ -130,12 +134,12 @@ public class ConfigurationService {
         };
     }
 
-    public Certificate getStubDcsSigningCert() throws CertificateException {
-        return getCertificateFromStoreUsingEnv("STUB_DCS_SIGNING_CERT_PARAM");
-    }
-
     public Key getStubDcsSigningKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
         return getKeyFromStoreUsingEnv("STUB_DCS_SIGNING_KEY_PARAM");
+    }
+
+    public Key getStubDcsEncryptionKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return getKeyFromStoreUsingEnv("STUB_DCS_ENCRYPTION_KEY_PARAM");
     }
 
     public String getDCSPostUrl() {

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -19,6 +19,13 @@ resource "aws_ssm_parameter" "passport_encryption_cert" {
   value       = var.passport_encryption_cert
 }
 
+resource "aws_ssm_parameter" "dcs_signing_cert" {
+  name        = "/${var.environment}/dcs/signing-cert"
+  description = "The DCS's public signing cert"
+  type        = "String"
+  value       = var.dcs_signing_cert
+}
+
 resource "aws_ssm_parameter" "dcs_encryption_cert" {
   name        = "/${var.environment}/dcs/encryption-cert"
   description = "The DCS's public encryption cert"
@@ -47,14 +54,6 @@ resource "aws_ssm_parameter" "dcs_post_url" {
   value       = var.use_localstack ? "http://localhost:4567/restapis/${aws_api_gateway_rest_api.ipv_cri_uk_passport.id}/local-dev/_user_request_/stub-dcs-check-passport" : var.dcs_post_url
 }
 
-resource "aws_ssm_parameter" "stub_dcs_signing_cert" {
-  count      = var.use_localstack ? 1 : 0
-  name        = "/${var.environment}/stub-dcs/signing-cert"
-  description = "The signing certificate used by the stub DCS"
-  type        = "String"
-  value       = var.stub_dcs_signing_cert
-}
-
 resource "aws_ssm_parameter" "stub_dcs_signing_key" {
   count      = var.use_localstack ? 1 : 0
   name        = "/${var.environment}/stub-dcs/signing-key"
@@ -63,12 +62,28 @@ resource "aws_ssm_parameter" "stub_dcs_signing_key" {
   value       = var.stub_dcs_signing_key
 }
 
+resource "aws_ssm_parameter" "stub_dcs_encryption_key" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/stub-dcs/encryption-key"
+  description = "The encryption key used by the stub DCS"
+  type        = "SecureString"
+  value       = var.stub_dcs_encryption_key
+}
+
 resource "aws_ssm_parameter" "local_only_passport_signing_key" {
   count      = var.use_localstack ? 1 : 0
   name        = "/${var.environment}/cri/passport/signing-key"
   description = "The signing key used by the passport CRI when running in local stack."
   type        = "SecureString"
   value       = var.local_only_passport_signing_key
+}
+
+resource "aws_ssm_parameter" "local_only_passport_encryption_key" {
+  count      = var.use_localstack ? 1 : 0
+  name        = "/${var.environment}/cri/passport/encryption-key"
+  description = "The encryption key used by the passport CRI when running in local stack."
+  type        = "SecureString"
+  value       = var.local_only_passport_encryption_key
 }
 
 resource "aws_ssm_parameter" "local_only_passport_tls_key" {
@@ -101,6 +116,7 @@ resource "aws_iam_role_policy" "get-parameters" {
           "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/${var.environment}/cri/passport/encryption-key",
           aws_ssm_parameter.passport_encryption_cert.arn,
           aws_ssm_parameter.dcs_encryption_cert.arn,
+          aws_ssm_parameter.dcs_signing_cert.arn,
           aws_ssm_parameter.dcs_tls_intermediate_cert.arn,
           aws_ssm_parameter.dcs_tls_root_cert.arn
         ]

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -29,8 +29,8 @@ module "passport" {
     "DCS_TLS_ROOT_CERT_PARAM"                  = "/${var.environment}/dcs/tls-root-certificate"
     "DCS_TLS_INTERMEDIATE_CERT_PARAM"          = "/${var.environment}/dcs/tls-intermediate-certificate"
     "DCS_RESPONSE_TABLE_NAME"                  = aws_dynamodb_table.dcs-response.name
-    "CRI_PASSPORT_AUTH_CODES_TABLE_NAME"                    = aws_dynamodb_table.cri-passport-auth-codes.name
-    "CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME"                 = aws_dynamodb_table.cri-passport-access-tokens.name
+    "CRI_PASSPORT_AUTH_CODES_TABLE_NAME"       = aws_dynamodb_table.cri-passport-auth-codes.name
+    "CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME"    = aws_dynamodb_table.cri-passport-access-tokens.name
   }
 }
 

--- a/terraform/lambda/stub-dcs.tf
+++ b/terraform/lambda/stub-dcs.tf
@@ -13,8 +13,10 @@ module "stub-dcs" {
   role_name              = "${var.environment}-stub-dcs-role"
 
   env_vars = {
-    "STUB_DCS_SIGNING_CERT_PARAM"        = aws_ssm_parameter.stub_dcs_signing_cert[0].name
+    "DCS_SIGNING_CERT_PARAM"             = aws_ssm_parameter.dcs_signing_cert.name
     "STUB_DCS_SIGNING_KEY_PARAM"         = aws_ssm_parameter.stub_dcs_signing_key[0].name
+    "STUB_DCS_ENCRYPTION_KEY_PARAM"      = aws_ssm_parameter.stub_dcs_encryption_key[0].name
+    "PASSPORT_CRI_SIGNING_CERT_PARAM"    = aws_ssm_parameter.passport_signing_cert.name
     "PASSPORT_CRI_ENCRYPTION_CERT_PARAM" = aws_ssm_parameter.passport_encryption_cert.name
   }
 }

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -13,6 +13,8 @@ variable "passport_signing_cert" { type = string }
 
 variable "passport_encryption_cert" { type = string }
 
+variable "dcs_signing_cert" { type = string }
+
 variable "dcs_encryption_cert" { type = string }
 
 variable "dcs_tls_intermediate_cert" { type = string }
@@ -34,10 +36,21 @@ variable "stub_dcs_signing_key" {
   default = ""
 }
 
+variable "stub_dcs_encryption_key" {
+  type    = string
+  default = ""
+}
+
 variable "local_only_passport_signing_key" {
   type    = string
   default = ""
 }
+
+variable "local_only_passport_encryption_key" {
+  type    = string
+  default = ""
+}
+
 variable "local_only_passport_tls_key" {
   type    = string
   default = ""


### PR DESCRIPTION
**See the companion PR here: https://github.com/alphagov/di-ipv-local-startup/pull/23**
**Also this one: https://github.com/alphagov/di-ipv-config/pull/81**


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds verification and decryption of the incoming payload from the
Passport CRI in the stub DCS. We then return a response to the CRI using
the correlation and request IDs contained in the original request.

This will help give us confidence that the request we're sending to DCS
is legit.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-476](https://govukverify.atlassian.net/browse/PYI-476)

