### PR TITLE
PYI-492: Set up new source set for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,3 +81,27 @@ spotless {
 		endWithNewline()
 	}
 }
+
+sourceSets {
+	integrationTest {
+		java {
+			srcDir 'src/integration-test/java'
+		}
+		resources {
+			srcDir 'src/integration-test/resources'
+		}
+		runtimeClasspath += sourceSets.main.runtimeClasspath
+		runtimeClasspath += sourceSets.test.runtimeClasspath
+		compileClasspath += sourceSets.main.compileClasspath
+		compileClasspath += sourceSets.test.compileClasspath
+	}
+}
+
+task intTest(type: Test) {
+	useJUnitPlatform()
+	testClassesDirs = sourceSets.integrationTest.output.classesDirs
+	classpath += sourceSets.integrationTest.runtimeClasspath
+	reports.junitXml.getOutputLocation().set(file("${project.buildDir}/int-test-results"))
+	reports.html.getOutputLocation().set(file("${project.buildDir}/int-test-reports"))
+	include 'uk/gov/di/ipv/cri/passport/integrationtest/**'
+}

--- a/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/HelloIntegrationTest.java
+++ b/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/HelloIntegrationTest.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.cri.passport.integrationtest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HelloIntegrationTest {
+
+    @Test
+    void helloIntegrationTest() {
+        assertEquals("HelloIntegrationTest", "HelloIntegrationTest");
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added a new source set and task for running integration tests.

### Why did it change

We want to be able to run our integration tests independently of our
unit tests. This is so we don’t have to set up a convoluted environment
when running the unit tests. Further work to be done to actually set up
that environment.


