### PR TITLE
BAU: Fix missing env var for dcs-response table name

### DIFF
--- a/terraform/lambda/dcs-credential.tf
+++ b/terraform/lambda/dcs-credential.tf
@@ -17,7 +17,7 @@ module "dcs-credential" {
   dcs_response_table_policy_arn                    = aws_iam_policy.policy-dcs-response-table.arn
 
   env_vars = {
-    "CRI_PASSPORT_AUTH_CODES_TABLE_NAME"    = aws_dynamodb_table.cri-passport-auth-codes.name
+    "DCS_RESPONSE_TABLE_NAME"    = aws_dynamodb_table.dcs-response.name
     "CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME" = aws_dynamodb_table.cri-passport-access-tokens.name
   }
 }

--- a/terraform/lambda/dcs-credential.tf
+++ b/terraform/lambda/dcs-credential.tf
@@ -17,7 +17,7 @@ module "dcs-credential" {
   dcs_response_table_policy_arn                    = aws_iam_policy.policy-dcs-response-table.arn
 
   env_vars = {
-    "DCS_RESPONSE_TABLE_NAME"    = aws_dynamodb_table.dcs-response.name
+    "DCS_RESPONSE_TABLE_NAME"               = aws_dynamodb_table.dcs-response.name
     "CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME" = aws_dynamodb_table.cri-passport-access-tokens.name
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add missing dynamoDB table name for the dcs-response lambda and remove unused table name var.
<!-- Describe the changes in detail - the "what"-->


