### PR TITLE
BAU: Update lambda iam policy to allow read permission from SSM

### DIFF
--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -11,7 +11,8 @@ data "aws_iam_policy_document" "lambda_can_assume_policy" {
     }
 
     actions = [
-      "sts:AssumeRole"
+      "sts:AssumeRole",
+      "ssm:GetParameter"
     ]
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added missing GetParameter permissions for SSM for the lambdas.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Currently the passport lambda is failing to retrieve things from SSM due to a missing policy permission.
<!-- Describe the reason these changes were made - the "why" -->

