### PR TITLE
Bau fix missing policy permission

### DIFF
--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -118,7 +118,8 @@ resource "aws_iam_role_policy" "get-parameters" {
           aws_ssm_parameter.dcs_encryption_cert.arn,
           aws_ssm_parameter.dcs_signing_cert.arn,
           aws_ssm_parameter.dcs_tls_intermediate_cert.arn,
-          aws_ssm_parameter.dcs_tls_root_cert.arn
+          aws_ssm_parameter.dcs_tls_root_cert.arn,
+          aws_ssm_parameter.dcs_post_url.arn
         ]
       }
     ]

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -11,7 +11,8 @@ data "aws_iam_policy_document" "lambda_can_assume_policy" {
     }
 
     actions = [
-      "sts:AssumeRole"
+      "sts:AssumeRole",
+      "ssm:GetParameter"
     ]
   }
 }

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -11,8 +11,7 @@ data "aws_iam_policy_document" "lambda_can_assume_policy" {
     }
 
     actions = [
-      "sts:AssumeRole",
-      "ssm:GetParameter"
+      "sts:AssumeRole"
     ]
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add dcs_post_url param to the parametere store policy resource list.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Currently the passport lambda fails to read this parameter from SSM due to the missing policy permission, and it requires this param in order to send a POST request out to the DCS validate api endpoint.

