### PR TITLE
PYI-452 Handle non 200 response from DCS

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
@@ -20,6 +20,12 @@ public class ApiGatewayResponseGenerator {
 
     private ApiGatewayResponseGenerator() {}
 
+    public static <T> APIGatewayProxyResponseEvent proxyJoseResponse(
+            int statusCode, String payload) {
+        Map<String, String> responseHeaders = Map.of(HttpHeaders.CONTENT_TYPE, "application/jose");
+        return proxyResponse(statusCode, payload, responseHeaders);
+    }
+
     public static <T> APIGatewayProxyResponseEvent proxyJsonResponse(int statusCode, T body) {
         Map<String, String> responseHeaders =
                 Map.of(HttpHeaders.CONTENT_TYPE, JSON_CONTENT_TYPE_VALUE);

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.cri.passport.domain.PassportFormRequest;
 import uk.gov.di.ipv.cri.passport.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.exceptions.EmptyDcsResponseException;
 import uk.gov.di.ipv.cri.passport.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.cri.passport.exceptions.IpvCryptoException;
 import uk.gov.di.ipv.cri.passport.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.passport.persistence.item.PassportCheckDao;
 import uk.gov.di.ipv.cri.passport.service.AuthorizationCodeService;
@@ -195,7 +196,8 @@ public class PassportHandler
         } catch (CertificateException
                 | java.text.ParseException
                 | JOSEException
-                | JsonProcessingException e) {
+                | JsonProcessingException
+                | IpvCryptoException e) {
             LOGGER.error(("Failed to unwrap response from DCS: " + e.getMessage()));
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/StubDcsHandler.java
@@ -83,7 +83,7 @@ public class StubDcsHandler
                     dcsResponse.getCorrelationId(),
                     dcsResponse.getRequestId());
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
+            return ApiGatewayResponseGenerator.proxyJoseResponse(
                     HttpStatus.SC_OK, signAndEncryptAndSign(dcsResponse));
 
         } catch (StubDcsException e) {

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
@@ -3,8 +3,11 @@ package uk.gov.di.ipv.cri.passport.service;
 import com.nimbusds.jose.JWSObject;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.domain.DcsSignedEncryptedResponse;
 import uk.gov.di.ipv.cri.passport.exceptions.EmptyDcsResponseException;
 import uk.gov.di.ipv.cri.passport.helpers.HttpClientSetUp;
@@ -16,12 +19,12 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Optional;
 
 public class PassportService {
 
     public static final String CONTENT_TYPE = "content-type";
     public static final String APPLICATION_JOSE = "application/jose";
+    private static final Logger LOGGER = LoggerFactory.getLogger(PassportService.class);
     private final ConfigurationService configurationService;
     private final DataStore<PassportCheckDao> dataStore;
     private final HttpClient httpClient;
@@ -53,13 +56,22 @@ public class PassportService {
         request.addHeader(CONTENT_TYPE, APPLICATION_JOSE);
         request.setEntity(new StringEntity(payload.serialize()));
 
-        Optional<HttpResponse> response = Optional.ofNullable(httpClient.execute(request));
+        HttpResponse response = httpClient.execute(request);
 
-        if (response.isEmpty()) {
+        if (response == null) {
             throw new EmptyDcsResponseException("Response from DCS is empty");
         }
 
-        return new DcsSignedEncryptedResponse(response.get().toString());
+        if (response.getStatusLine().getStatusCode() != 200) {
+            LOGGER.error(
+                    String.format(
+                            "Response from DCS has status code: %d",
+                            response.getStatusLine().getStatusCode()));
+            throw new HttpResponseException(
+                    response.getStatusLine().getStatusCode(), "DCS responded with an error");
+        }
+
+        return new DcsSignedEncryptedResponse(response.toString());
     }
 
     public void persistDcsResponse(PassportCheckDao responsePayload) {

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
@@ -6,6 +6,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.domain.DcsSignedEncryptedResponse;
@@ -71,7 +72,7 @@ public class PassportService {
                     response.getStatusLine().getStatusCode(), "DCS responded with an error");
         }
 
-        return new DcsSignedEncryptedResponse(response.toString());
+        return new DcsSignedEncryptedResponse(EntityUtils.toString(response.getEntity()));
     }
 
     public void persistDcsResponse(PassportCheckDao responsePayload) {

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/PassportServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/PassportServiceTest.java
@@ -1,8 +1,11 @@
 package uk.gov.di.ipv.cri.passport.service;
 
 import com.nimbusds.jose.JWSObject;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +43,8 @@ class PassportServiceTest {
     @Mock HttpClient httpClient;
     @Mock JWSObject jwsObject;
     @Mock HttpResponse httpResponse;
+    @Mock StatusLine statusLine;
+    @Mock HttpEntity entity;
 
     @Captor ArgumentCaptor<HttpPost> httpPost;
 
@@ -54,6 +59,8 @@ class PassportServiceTest {
     void shouldPostToDcsEndpoint() throws IOException, EmptyDcsResponseException {
         String expectedPayload = "Test";
         when(configurationService.getDCSPostUrl()).thenReturn(CHECK_PASSPORT_URI);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(200);
         when(httpResponse.toString()).thenReturn(EXPECTED_RESPONSE);
         when(httpClient.execute(any(HttpPost.class))).thenReturn(httpResponse);
         when(jwsObject.serialize()).thenReturn(expectedPayload);
@@ -68,6 +75,25 @@ class PassportServiceTest {
         assertEquals(expectedPayload, EntityUtils.toString(httpPost.getValue().getEntity()));
 
         assertEquals(EXPECTED_RESPONSE, actualResponse.getPayload());
+    }
+
+    @Test
+    void shouldReturnAnErrorWhenDCSRespondsWithNon200() throws IOException {
+        String expectedPayload = "Test";
+        when(configurationService.getDCSPostUrl()).thenReturn(CHECK_PASSPORT_URI);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(500);
+        when(httpClient.execute(any(HttpPost.class))).thenReturn(httpResponse);
+        when(jwsObject.serialize()).thenReturn(expectedPayload);
+
+        HttpResponseException httpResponseException =
+                assertThrows(
+                        HttpResponseException.class, () -> underTest.dcsPassportCheck(jwsObject));
+        verify(httpClient, times(1)).execute(httpPost.capture());
+        assertEquals(
+                "status code: 500, reason phrase: DCS responded with an error",
+                httpResponseException.getMessage());
+        assertEquals(500, httpResponseException.getStatusCode());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/PassportServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/PassportServiceTest.java
@@ -7,6 +7,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,10 +59,11 @@ class PassportServiceTest {
     @Test
     void shouldPostToDcsEndpoint() throws IOException, EmptyDcsResponseException {
         String expectedPayload = "Test";
+        HttpEntity httpEntity = new StringEntity(expectedPayload);
         when(configurationService.getDCSPostUrl()).thenReturn(CHECK_PASSPORT_URI);
         when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(httpEntity);
         when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.toString()).thenReturn(EXPECTED_RESPONSE);
         when(httpClient.execute(any(HttpPost.class))).thenReturn(httpResponse);
         when(jwsObject.serialize()).thenReturn(expectedPayload);
 
@@ -74,7 +76,7 @@ class PassportServiceTest {
                 "application/jose", httpPost.getValue().getFirstHeader("content-type").getValue());
         assertEquals(expectedPayload, EntityUtils.toString(httpPost.getValue().getEntity()));
 
-        assertEquals(EXPECTED_RESPONSE, actualResponse.getPayload());
+        assertEquals(expectedPayload, actualResponse.getPayload());
     }
 
     @Test

--- a/terraform/lambda/passport.tf
+++ b/terraform/lambda/passport.tf
@@ -19,6 +19,7 @@ module "passport" {
 
   env_vars = {
     "DCS_ENCRYPTION_CERT_PARAM"                = "/${var.environment}/dcs/encryption-cert"
+    "DCS_SIGNING_CERT_PARAM"                   = "/${var.environment}/dcs/signing-cert"
     "PASSPORT_CRI_SIGNING_KEY_PARAM"           = "/${var.environment}/cri/passport/signing-key"
     "PASSPORT_CRI_ENCRYPTION_KEY_PARAM"        = "/${var.environment}/cri/passport/encryption-key"
     "PASSPORT_CRI_TLS_KEY_PARAM"               = "/${var.environment}/cri/passport/tls-key"


### PR DESCRIPTION
Check the response from DCS and if the status code is not 200 then log
the status code and return an error to passport frontend. Note that the
response entity isn't being logged with the error just in case it contains
something sensitive.


### What changed
Check the response from DCS and if the status code is not 200 then log
the status code and return an error to passport frontend. Note that the
response entity isn't being logged with the error just in case it contains
something sensitive.

Guidance on DCS passport validity check is available here showing the status code should be 200 for a successful check: https://dcs-pilot-docs.cloudapps.digital/api-reference/#interpret-the-passport-validity-response


### Why did it change
Previously we were attempting to parse non-200 responses into a JWS which threw a confusing error.

### Issue tracking

## Checklists

### Environment variables or secrets

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
