### PR TITLE
Pyi 452/fix error handling

### DIFF
--- a/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DataStoreIT.java
+++ b/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DataStoreIT.java
@@ -63,7 +63,7 @@ public class DataStoreIT {
 
         Map<String, Object> savedDcsResponse = savedPassportCheck.getMap("dcsResponse");
         assertEquals(validDcsResponse.isValid(), savedDcsResponse.get("valid"));
-        assertEquals(validDcsResponse.getError(), savedDcsResponse.get("error"));
+        assertEquals(validDcsResponse.isError(), savedDcsResponse.get("error"));
         assertEquals(
                 Arrays.toString(validDcsResponse.getErrorMessage()),
                 savedDcsResponse.get("errorMessage").toString());

--- a/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/domain/DcsResponse.java
@@ -23,8 +23,8 @@ public class DcsResponse {
     public DcsResponse(
             @JsonProperty(value = "correlationId", required = true) UUID correlationId,
             @JsonProperty(value = "requestId", required = true) UUID requestId,
-            @JsonProperty(value = "error", required = true) boolean error,
-            @JsonProperty(value = "valid", required = true) boolean valid,
+            @JsonProperty(value = "error", required = false) boolean error,
+            @JsonProperty(value = "valid", required = false) boolean valid,
             @JsonProperty(value = "errorMessage", required = false) String[] errorMessage) {
         this.correlationId = correlationId;
         this.requestId = requestId;
@@ -41,7 +41,7 @@ public class DcsResponse {
         return requestId;
     }
 
-    public boolean getError() {
+    public boolean isError() {
         return error;
     }
 

--- a/src/main/java/uk/gov/di/ipv/cri/passport/domain/PassportFormRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/domain/PassportFormRequest.java
@@ -5,15 +5,16 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.UUID;
 
 @DynamoDbBean
 public class PassportFormRequest {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private static final String TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
     private static final String TIME_ZONE = "UTC";
 
     @JsonProperty private UUID correlationId;
@@ -47,7 +48,7 @@ public class PassportFormRequest {
         this.expiryDate = expiryDate;
         this.correlationId = UUID.randomUUID();
         this.requestId = UUID.randomUUID();
-        this.timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+        this.timestamp = new SimpleDateFormat(TIMESTAMP_DATE_FORMAT).format(new Date());
     }
 
     public UUID getCorrelationId() {

--- a/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/error/ErrorResponse.java
@@ -12,7 +12,8 @@ public enum ErrorResponse {
     FAILED_TO_PREPARE_DCS_PAYLOAD(1003, "Failed to prepare DCS payload"),
     ERROR_CONTACTING_DCS(1004, "Error when contacting DCS for passport check"),
     FAILED_TO_UNWRAP_DCS_RESPONSE(1005, "Failed to unwrap Dcs response"),
-    ERROR_GETTING_RESPONSE_FROM_DCS(1006, "No response was returned from DCS");
+    ERROR_GETTING_RESPONSE_FROM_DCS(1006, "No response was returned from DCS"),
+    DCS_RETURNED_AN_ERROR(1007, "DCS returned an error response");
 
     private final int code;
     private final String message;

--- a/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/helpers/ApiGatewayResponseGenerator.java
@@ -20,8 +20,7 @@ public class ApiGatewayResponseGenerator {
 
     private ApiGatewayResponseGenerator() {}
 
-    public static <T> APIGatewayProxyResponseEvent proxyJoseResponse(
-            int statusCode, String payload) {
+    public static APIGatewayProxyResponseEvent proxyJoseResponse(int statusCode, String payload) {
         Map<String, String> responseHeaders = Map.of(HttpHeaders.CONTENT_TYPE, "application/jose");
         return proxyResponse(statusCode, payload, responseHeaders);
     }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -141,8 +141,8 @@ public class PassportHandler
     private void validateDcsResponse(DcsResponse dcsResponse)
             throws HttpResponseExceptionWithErrorBody {
         if (dcsResponse.isError()) {
-            LOGGER.error(
-                    "DCS encounterd error: {}", Arrays.toString(dcsResponse.getErrorMessage()));
+            String errorMessage = Arrays.toString(dcsResponse.getErrorMessage());
+            LOGGER.error("DCS encounterd error: {}", errorMessage);
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.DCS_RETURNED_AN_ERROR);
         }

--- a/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/lambda/PassportHandler.java
@@ -34,6 +34,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,9 @@ public class PassportHandler
             JWSObject preparedDcsPayload = preparePayload(passportFormRequest);
             DcsSignedEncryptedResponse dcsResponse = doPassportCheck(preparedDcsPayload);
             DcsResponse unwrappedDcsResponse = unwrapDcsResponse(dcsResponse);
+
+            validateDcsResponse(unwrappedDcsResponse);
+
             PassportCheckDao passportCheckDao =
                     new PassportCheckDao(
                             UUID.randomUUID().toString(),
@@ -132,6 +136,16 @@ public class PassportHandler
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_QUERY_PARAMETERS);
         }
         checkQueryStringCanBeParsedToAuthenticationRequest(queryStringParameters);
+    }
+
+    private void validateDcsResponse(DcsResponse dcsResponse)
+            throws HttpResponseExceptionWithErrorBody {
+        if (dcsResponse.isError()) {
+            LOGGER.error(
+                    "DCS encounterd error: {}", Arrays.toString(dcsResponse.getErrorMessage()));
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.DCS_RETURNED_AN_ERROR);
+        }
     }
 
     private void checkQueryStringCanBeParsedToAuthenticationRequest(

--- a/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/DcsResponseTypeConverter.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/persistence/item/DcsResponseTypeConverter.java
@@ -23,7 +23,7 @@ public class DcsResponseTypeConverter implements AttributeConverter<DcsResponse>
                                         .build(),
                         "requestId",
                                 AttributeValue.builder().s(input.getRequestId().toString()).build(),
-                        "error", AttributeValue.builder().bool(input.getError()).build(),
+                        "error", AttributeValue.builder().bool(input.isError()).build(),
                         "valid", AttributeValue.builder().bool(input.isValid()).build(),
                         "errorMessage",
                                 Objects.isNull(input.getErrorMessage())

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/ConfigurationService.java
@@ -28,7 +28,6 @@ public class ConfigurationService {
     private static final String LOCALHOST_URI = "http://localhost:" + LOCALHOST_PORT;
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
     private static final String IS_LOCAL = "IS_LOCAL";
-    private static final String DEFAULT_DYNAMODB_URI = "http://localhost:4567";
 
     private final SSMProvider ssmProvider;
 

--- a/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/passport/service/PassportService.java
@@ -64,10 +64,8 @@ public class PassportService {
         }
 
         if (response.getStatusLine().getStatusCode() != 200) {
-            LOGGER.error(
-                    String.format(
-                            "Response from DCS has status code: %d",
-                            response.getStatusLine().getStatusCode()));
+            int statusCode = response.getStatusLine().getStatusCode();
+            LOGGER.error("Response from DCS has status code: {}", statusCode);
             throw new HttpResponseException(
                     response.getStatusLine().getStatusCode(), "DCS responded with an error");
         }

--- a/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCryptographyServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/passport/service/DcsCryptographyServiceTest.java
@@ -129,7 +129,7 @@ class DcsCryptographyServiceTest {
 
         assertEquals(expectedDcsResponse.getCorrelationId(), actualDcsResponse.getCorrelationId());
         assertEquals(expectedDcsResponse.getRequestId(), actualDcsResponse.getRequestId());
-        assertEquals(expectedDcsResponse.getError(), actualDcsResponse.getError());
+        assertEquals(expectedDcsResponse.isError(), actualDcsResponse.isError());
         assertEquals(expectedDcsResponse.isValid(), actualDcsResponse.isValid());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Fix error handling for the DCS response so that when DCS returns an error we log that error and return a 500 error response.
- Fix the DCSPayload timestamp field date format to follow what DCS expects.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Improve our handling of the possible DCS responses and fix the DCS verification of our passport validation requests.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-452](https://govukverify.atlassian.net/browse/PYI-452)
