### PR TITLE
PYI 619 add config to contain signature verification cert in SSM

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -176,6 +176,9 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
+          CLIENT_1_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_1/signing_cert"
+          CLIENT_2_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_2/signing_cert"
+          CLIENT_3_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_3/signing_cert"
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -176,9 +176,6 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
-          CLIENT_1_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_1/signing_cert"
-          CLIENT_2_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_2/signing_cert"
-          CLIENT_3_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_3/signing_cert"
           CLIENT_TEST_PARAM: !Sub "/${Environment}/cri/passport/config/test/signing_cert"
       Events:
         IPVCriUKPassportAPI:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -177,6 +177,9 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           CLIENT_TEST_PARAM: !Sub "/${Environment}/cri/passport/config/test/signing_cert"
+      Policies:
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/cri/passport/config/*
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -179,6 +179,7 @@ Resources:
           CLIENT_1_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_1/signing_cert"
           CLIENT_2_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_2/signing_cert"
           CLIENT_3_SIGNING_CERT_PARAM: !Sub "/${Environment}/cri/passport/config/client_3/signing_cert"
+          CLIENT_TEST_PARAM: !Sub "/${Environment}/cri/passport/config/test/signing_cert"
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -95,27 +95,6 @@ resource "aws_ssm_parameter" "local_only_passport_tls_key" {
   value       = var.local_only_passport_tls_key
 }
 
-resource "aws_ssm_parameter" "signing_cert_cli_1" {
-  name        = "/${var.environment}/cri/passport/config/client_1/signing_cert"
-  description = "The certificate used by Client_1"
-  type        = "String"
-  value       = var.signing_cert_cli_1
-}
-
-resource "aws_ssm_parameter" "signing_cert_cli_2" {
-  name        = "/${var.environment}/cri/passport/config/client_2/signing_cert"
-  description = "The certificate used by Client_2"
-  type        = "String"
-  value       = var.signing_cert_cli_2
-}
-
-resource "aws_ssm_parameter" "signing_cert_cli_3" {
-  name        = "/${var.environment}/cri/passport/config/client_3/signing_cert"
-  description = "The certificate used by Client_3"
-  type        = "String"
-  value       = var.signing_cert_cli_3
-}
-
 resource "aws_ssm_parameter" "signing_cert_test" {
   name        = "/${var.environment}/cri/passport/config/test/signing_cert"
   description = "The certificate used by Client_test"
@@ -149,10 +128,7 @@ resource "aws_iam_role_policy" "get-parameters" {
           aws_ssm_parameter.dcs_tls_intermediate_cert.arn,
           aws_ssm_parameter.dcs_tls_root_cert.arn,
           aws_ssm_parameter.dcs_post_url.arn,
-          aws_ssm_parameter.signing_cert_cli_1.arn,
-          aws_ssm_parameter.signing_cert_cli_2.arn,
-          aws_ssm_parameter.signing_cert_cli_3.arn,
-          aws_ssm_parameter.signing_cert_test
+          aws_ssm_parameter.signing_cert_test.arn
         ]
       }
     ]

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -95,6 +95,27 @@ resource "aws_ssm_parameter" "local_only_passport_tls_key" {
   value       = var.local_only_passport_tls_key
 }
 
+resource "aws_ssm_parameter" "signing_cert_cli_1" {
+  name        = "/${var.environment}/cri/passport/config/client_1/signing_cert"
+  description = "The certificate used by Client_1"
+  type        = "String"
+  value       = var.signing_cert_cli_1
+}
+
+resource "aws_ssm_parameter" "signing_cert_cli_2" {
+  name        = "/${var.environment}/cri/passport/config/client_2/signing_cert"
+  description = "The certificate used by Client_2"
+  type        = "String"
+  value       = var.signing_cert_cli_2
+}
+
+resource "aws_ssm_parameter" "signing_cert_cli_3" {
+  name        = "/${var.environment}/cri/passport/config/client_3/signing_cert"
+  description = "The certificate used by Client_3"
+  type        = "String"
+  value       = var.signing_cert_cli_3
+}
+
 resource "aws_iam_role_policy" "get-parameters" {
   name = "get-parameters"
   role = module.passport.iam_role_id
@@ -120,7 +141,10 @@ resource "aws_iam_role_policy" "get-parameters" {
           aws_ssm_parameter.dcs_signing_cert.arn,
           aws_ssm_parameter.dcs_tls_intermediate_cert.arn,
           aws_ssm_parameter.dcs_tls_root_cert.arn,
-          aws_ssm_parameter.dcs_post_url.arn
+          aws_ssm_parameter.dcs_post_url.arn,
+          aws_ssm_parameter.signing_cert_cli_1.arn,
+          aws_ssm_parameter.signing_cert_cli_2.arn,
+          aws_ssm_parameter.signing_cert_cli_3.arn
         ]
       }
     ]

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -116,6 +116,13 @@ resource "aws_ssm_parameter" "signing_cert_cli_3" {
   value       = var.signing_cert_cli_3
 }
 
+resource "aws_ssm_parameter" "signing_cert_test" {
+  name        = "/${var.environment}/cri/passport/config/test/signing_cert"
+  description = "The certificate used by Client_test"
+  type        = "String"
+  value       = var.signing_cert_test
+}
+
 resource "aws_iam_role_policy" "get-parameters" {
   name = "get-parameters"
   role = module.passport.iam_role_id
@@ -144,7 +151,8 @@ resource "aws_iam_role_policy" "get-parameters" {
           aws_ssm_parameter.dcs_post_url.arn,
           aws_ssm_parameter.signing_cert_cli_1.arn,
           aws_ssm_parameter.signing_cert_cli_2.arn,
-          aws_ssm_parameter.signing_cert_cli_3.arn
+          aws_ssm_parameter.signing_cert_cli_3.arn,
+          aws_ssm_parameter.signing_cert_test
         ]
       }
     ]

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -27,6 +27,8 @@ variable "signing_cert_cli_2" { type = string }
 
 variable "signing_cert_cli_3" { type = string }
 
+variable "signing_cert_test" { type = string }
+
 variable "dcs_post_url" {
   type    = string
   default = ""

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -21,6 +21,12 @@ variable "dcs_tls_intermediate_cert" { type = string }
 
 variable "dcs_tls_root_cert" { type = string }
 
+variable "signing_cert_cli_1" { type = string }
+
+variable "signing_cert_cli_2" { type = string }
+
+variable "signing_cert_cli_3" { type = string }
+
 variable "dcs_post_url" {
   type    = string
   default = ""

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -21,12 +21,6 @@ variable "dcs_tls_intermediate_cert" { type = string }
 
 variable "dcs_tls_root_cert" { type = string }
 
-variable "signing_cert_cli_1" { type = string }
-
-variable "signing_cert_cli_2" { type = string }
-
-variable "signing_cert_cli_3" { type = string }
-
 variable "signing_cert_test" { type = string }
 
 variable "dcs_post_url" {


### PR DESCRIPTION

### What changed
setting up  the config variables that are used to pull certificates from SSM . These variables will be used in Configuration 
service ultimately

- [PYI-619](https://govukverify.atlassian.net/browse/PYI-619)
