### PR TITLE
PYI-612: Add shared attributes signing cert var

### DIFF
--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -48,6 +48,13 @@ resource "aws_ssm_parameter" "dcs_tls_root_cert" {
   value       = var.dcs_tls_root_cert
 }
 
+resource "aws_ssm_parameter" "core_shared_attributes_signing_cert" {
+  name        = "/${var.environment}/core/shared-attributes-signing-cert"
+  description = "The IPV core's shared attributes signing certificate"
+  type        = "String"
+  value       = var.core_shared_attributes_signing_cert
+}
+
 resource "aws_ssm_parameter" "dcs_post_url" {
   name        = "/${var.environment}/dcs/post-url"
   description = "The DCS's url for passport valid check"

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -7,6 +7,8 @@ variable "use_localstack" {
   default = false
 }
 
+variable "core_shared_attributes_signing_cert" { type = string }
+
 variable "passport_tls_cert" { type = string }
 
 variable "passport_signing_cert" { type = string }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The signing cert for verifying the shared attributes JWS has been added
to the config repo. See here: https://github.com/alphagov/di-ipv-config/pull/121 
We need to add this variable here to stop the terraform
from breaking.

This sets the cert as a parameter in the parameter store. The name of
the parameter may need changing now we're managing config in a
structured way.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-612](https://govukverify.atlassian.net/browse/PYI-612)
