### PR TITLE
PYI-620 

### DIFF
--- a/lambdas/jwtverification/build.gradle
+++ b/lambdas/jwtverification/build.gradle
@@ -15,10 +15,12 @@ repositories {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
 			"com.nimbusds:nimbus-jose-jwt:9.15.2",
 			project(":lib")
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-junit-jupiter:4.1.0",
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
 			"org.mockito:mockito-core:4.1.0"

--- a/lambdas/jwtverification/src/test/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandlerTest.java
+++ b/lambdas/jwtverification/src/test/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandlerTest.java
@@ -14,27 +14,44 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
+import java.io.ByteArrayInputStream;
 import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import static org.mockito.Mockito.when;
+@ExtendWith(MockitoExtension.class)
 class JwtVerificationHandlerTest {
 
-    private final JwtVerificationHandler underTest = new JwtVerificationHandler();
+    @Mock
+    private ConfigurationService configurationService;
+
+    private  JwtVerificationHandler underTest ;
 
     private SignedJWT signedJWT;
 
-    @Mock Context context;
+    @Mock
+    Context context;
+
+    private static final String BASE64_CERT =
+            "MIIDZzCCAk+gAwIBAgIBATANBgkqhkiG9w0BAQsFADB3MQswCQYDVQQGEwJVSzEXMBUGA1UECBMOR3JlYXRlciBMb25kb24xDzANBgNVBAcTBkxvbmRvbjEXMBUGA1UEChMOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsTA0dEUzEXMBUGA1UEAxMOTXkgY29tbW9uIG5hbWUwHhcNMjIwMTMxMTExNDM3WhcNMjMwMTMxMTExNDM3WjB3MQswCQYDVQQGEwJVSzEXMBUGA1UECBMOR3JlYXRlciBMb25kb24xDzANBgNVBAcTBkxvbmRvbjEXMBUGA1UEChMOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsTA0dEUzEXMBUGA1UEAxMOTXkgY29tbW9uIG5hbWUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCRZHUZZOG6W9hrxx/qo8hl9c6rd/0HCed7Vd2DidJ2yRTjbMZ0q8S9OdxTO2H0Wrrt1r4k6RqRKDImdcRqsJKM8iamcS8kYnQHUdHaqnwcFkDtM29A/57V0by2H/fUJss5MqLCE6hBKnrNc/WrI5VCx2LNEe833yDM1fYDjh0CKJK8e0bXMRCTn1sl2wmmBucRaXIZa2msey6SpgxG7REuVsc+Y804yuZAOaTyFP485D8QMVjwl/KRGVich7XYaxTZI3N4KGpS0K9Ui0U+FwuCxsDDdABQ1B2acINZ1ookghLp3EsnpvUJlHw+rPvvqOd18D64TQIDm67O4jK+c4zAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADVrL7p+L5Y38LSMkIJF+fNTXN2xb0cFwn6fHLiD1Jpvq2LoMU18P1lBT4ZFsPFM8OPk58m6Nid8GVJpp+Pz/8a7Uhx3PfpB2uKzmpwBktBu5xpdE+DS/omxnlY91vAnCJaA3NdBYaDGavbs3J0rCR5DpH56hXikmtR3IzGYgrX3TJJghl6vWXZsW/J9nG5+W62SOX9hQUzj3rkXYKfcugODRAsBSC72zOgOU8+7MyDJkX9ndS6UOA5owUDonv75rVEDHNV/vcKrIrs43gmmcQ+PnxU7RwbCsUAN/si4emkR8zAdCQVvi0VFh9woikHOZvlXwm/GGINiLDi8E3kxL10=";
 
     @BeforeEach
-    void setUp() throws JOSEException {
+    void setUp() throws JOSEException, CertificateException {
         List<String> givenNames = Arrays.asList("Daniel", "Dan", "Danny");
         List<String> dateOfBirths = Arrays.asList("01/01/1980", "02/01/1980");
         List<String> addresses = Collections.singletonList("123 random street, M13 7GE");
@@ -53,11 +70,17 @@ class JwtVerificationHandlerTest {
         signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claimsSet);
 
         signedJWT.sign(signer);
+
+        underTest = new JwtVerificationHandler(configurationService);
     }
 
     @Test
-    void shouldReturn200WhenGivenValidJWT() {
+    void shouldReturn200WhenGivenValidJWT() throws CertificateException {
+        when(configurationService.getClientCert("TEST")).thenReturn(getCertificate(BASE64_CERT));
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
         event.setBody(signedJWT.serialize());
 
         var response = underTest.handleRequest(event, context);
@@ -65,8 +88,12 @@ class JwtVerificationHandlerTest {
     }
 
     @Test
-    void shouldReturnClaimsAsJsonFromJWT() throws JsonProcessingException {
+    void shouldReturnClaimsAsJsonFromJWT() throws JsonProcessingException, CertificateException {
+        when(configurationService.getClientCert("TEST")).thenReturn(getCertificate(BASE64_CERT));
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
         event.setBody(signedJWT.serialize());
 
         var response = underTest.handleRequest(event, context);
@@ -79,8 +106,11 @@ class JwtVerificationHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfMissingJWT() throws JsonProcessingException {
+    void shouldReturn400IfMissingJWT() throws JsonProcessingException, CertificateException {
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
         event.setBody(null);
 
         var response = underTest.handleRequest(event, context);
@@ -95,6 +125,9 @@ class JwtVerificationHandlerTest {
     @Test
     void shouldReturn400IfFailedToParseJWT() throws JsonProcessingException {
         var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
         event.setBody("Not a valid JWT");
 
         var response = underTest.handleRequest(event, context);
@@ -105,4 +138,11 @@ class JwtVerificationHandlerTest {
         assertEquals(ErrorResponse.FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT.getCode(), error.get("code"));
         assertEquals(ErrorResponse.FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT.getMessage(), error.get("message"));
     }
+
+    private Certificate getCertificate(String base64certificate) throws CertificateException {
+        byte[] binaryCertificate = Base64.getDecoder().decode(base64certificate);
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        return factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
+    }
 }
+

--- a/lambdas/jwtverification/src/test/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandlerTest.java
+++ b/lambdas/jwtverification/src/test/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandlerTest.java
@@ -25,6 +25,7 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -139,10 +140,40 @@ class JwtVerificationHandlerTest {
         assertEquals(ErrorResponse.FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT.getMessage(), error.get("message"));
     }
 
+    @Test
+    void shouldReturn400IFClientIdIsNotSet() throws JsonProcessingException {
+        var event = new APIGatewayProxyRequestEvent();
+
+        var response = underTest.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> error = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_CLIENT_QUERY_PARAMETERS.getCode(), error.get("code"));
+        assertEquals(ErrorResponse.MISSING_CLIENT_QUERY_PARAMETERS.getMessage(), error.get("message"));
+    }
+
+    @Test
+    void shouldReturn200WithValidCertificate() throws CertificateException {
+        var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
+        event.setBody(signedJWT.serialize());
+        when(configurationService.getClientCert("TEST")).thenReturn(getCertificate(BASE64_CERT));
+
+        var response = underTest.handleRequest(event, context);
+
+        X509Certificate x509Certificate = (X509Certificate) getCertificate(BASE64_CERT);
+        assertEquals(configurationService.getClientCert("TEST"),getCertificate(BASE64_CERT));
+        assertEquals("CN=My common name, OU=GDS, O=Cabinet Office, L=London, ST=Greater London, C=UK",x509Certificate.getSubjectDN().getName());
+    }
+
     private Certificate getCertificate(String base64certificate) throws CertificateException {
         byte[] binaryCertificate = Base64.getDecoder().decode(base64certificate);
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         return factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
     }
+
 }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -15,7 +15,9 @@ public enum ErrorResponse {
     ERROR_GETTING_RESPONSE_FROM_DCS(1006, "No response was returned from DCS"),
     DCS_RETURNED_AN_ERROR(1007, "DCS returned an error response"),
     MISSING_SHARED_ATTRIBUTES_JWT(1008, "Missing shared attributes JWT from request body"),
-    FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT(1009, "Failed to parse shared attributes JWT");
+    FAILED_TO_PARSE_SHARED_ATTRIBUTES_JWT(1009, "Failed to parse shared attributes JWT"),
+    MISSING_CLIENT_QUERY_PARAMETERS(1010, "Missing query parameters for client id"),
+    FAILED_TO_RETRIEVE_CERTIFICATE(1011, "Failed to retrieve client certificate from SSM");
 
     private final int code;
     private final String message;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -184,13 +184,8 @@ public class ConfigurationService {
     }
 
     public Certificate getClientCert(String clientId) throws CertificateException {
-        String value = ssmProvider.get(
-                String.format("/%s/cri/passport/config/%s/signing_cert",
-                        System.getenv("ENVIRONMENT"), clientId));
-        if (StringUtils.isBlank(value)) {
-            throw new CertificateException(String.format("Unable to retrieve certificate for %s", clientId ));
-        }
-        return getCertificateFromStoreUsingEnv(String.format("CLIENT_%s_PARAM",clientId.toUpperCase()));
+        return getCertificateFromStoreUsingEnv(String.format("/%s/cri/passport/config/%s/signing_cert",
+                System.getenv("ENVIRONMENT"), clientId));
     }
 
 }


### PR DESCRIPTION
### What changed

From the client id provided in the request param, the relevant certificate is retrieved from SSM that will be used later for JWT verification

- [PYI-620](https://govukverify.atlassian.net/browse/PYI-620)

### Other considerations

The certiticate is set in aws under 
"/${var.environment}/cri/passport/config/test/signing_cert" ... where "test" refers to the client id . 
This config is likely to be changed , ongoing dev ..
