### PR TITLE
PYI-634: Load client cert from SSM by using constructed parameter-nam…

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -74,6 +74,10 @@ public class ConfigurationService {
         return ssmProvider.get(System.getenv(environmentVariable));
     }
 
+    private String getParameterFromStore(String parameterName) {
+        return ssmProvider.get(parameterName);
+    }
+
     private String getDecryptedParameterFromStoreUsingEnv(String environmentVariable) {
         return ssmProvider.withDecryption().get(System.getenv(environmentVariable));
     }
@@ -82,6 +86,14 @@ public class ConfigurationService {
             throws CertificateException {
         byte[] binaryCertificate =
                 Base64.getDecoder().decode(getParameterFromStoreUsingEnv(environmentVariable));
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        return factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
+    }
+
+    private Certificate getCertificateFromStore(String parameteraName)
+            throws CertificateException {
+        byte[] binaryCertificate =
+                Base64.getDecoder().decode(getParameterFromStore(parameteraName));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         return factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
     }
@@ -183,7 +195,7 @@ public class ConfigurationService {
     }
 
     public Certificate getClientCert(String clientId) throws CertificateException {
-        return getCertificateFromStoreUsingEnv(String.format("/%s/cri/passport/config/%s/signing_cert",
+        return getCertificateFromStore(String.format("/%s/cri/passport/config/%s/signing_cert",
                 System.getenv("ENVIRONMENT"), clientId));
     }
 


### PR DESCRIPTION
…e rather than an environment variable

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Load client cert from SSM using the constructed parameter-name rather than an environment variable.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The name of the parameter-store variable is constructed by values passed into the cri so we don't know which param name to use until the time of the request. Trying to have a list of ENV vars to keep track of these possible param names will be messy and complicated.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-634](https://govukverify.atlassian.net/browse/PYI-634)

