### PR TITLE
PYI-638: Update DcsCredentialHandler to return PassportCredentialIssuerResponse

### DIFF
--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandler.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.passport.dcscredential.domain.PassportCredentialIssuerResponse;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
@@ -69,7 +70,9 @@ public class DcsCredentialHandler
 
             PassportCheckDao credential = dcsCredentialService.getDcsCredential(resourceId);
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, credential);
+            PassportCredentialIssuerResponse passportCredentialIssuerResponse = PassportCredentialIssuerResponse.fromPassportCheckDao(credential);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, passportCredentialIssuerResponse);
         } catch (ParseException e) {
             LOGGER.error("Failed to parse access token");
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
@@ -1,0 +1,173 @@
+package uk.gov.di.ipv.cri.passport.dcscredential.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class PassportCredentialIssuerResponse {
+
+    @JsonProperty private Attributes attributes;
+    @JsonProperty private String resourceId;
+
+    public PassportCredentialIssuerResponse() {}
+
+    public PassportCredentialIssuerResponse(String resourceId, Attributes attributes) {
+        this.resourceId = resourceId;
+        this.attributes = attributes;
+    }
+
+    public static PassportCredentialIssuerResponse fromPassportCheckDao(
+            PassportCheckDao credential) {
+        Attributes attributes =
+                new Attributes.Builder()
+                        .setFamilyName(credential.getAttributes().getSurname())
+                        .setGivenNames(credential.getAttributes().getForenames())
+                        .setPassportNumber(credential.getAttributes().getPassportNumber())
+                        .setDateOfBirth(credential.getAttributes().getDateOfBirth())
+                        .setExpiryDate(credential.getAttributes().getExpiryDate())
+                        .setRequestId(credential.getAttributes().getRequestId())
+                        .setCorrelationId(credential.getAttributes().getCorrelationId())
+                        .setDcsResponse(credential.getAttributes().getDcsResponse())
+                        .build();
+        return new PassportCredentialIssuerResponse(credential.getResourceId(), attributes);
+    }
+
+    public Attributes getAttributes() {
+        return attributes;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public static class Attributes {
+
+        @JsonProperty private final String familyName;
+        @JsonProperty private final String[] givenNames;
+        @JsonProperty private final String passportNumber;
+        @JsonProperty private final LocalDate dateOfBirth;
+        @JsonProperty private final LocalDate expiryDate;
+        @JsonProperty private final UUID requestId;
+        @JsonProperty private final UUID correlationId;
+        @JsonProperty private final DcsResponse dcsResponse;
+
+        @JsonCreator
+        public Attributes(
+                @JsonProperty(value = "familyName", required = true) String familyName,
+                @JsonProperty(value = "givenNames", required = true) String[] givenNames,
+                @JsonProperty(value = "passportNumber", required = true) String passportNumber,
+                @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
+                @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
+                @JsonProperty(value = "requestId", required = true) UUID requestId,
+                @JsonProperty(value = "correlationId", required = true) UUID correlationId,
+                @JsonProperty(value = "dcsResponse", required = true) DcsResponse dcsResponse) {
+            this.familyName = familyName;
+            this.givenNames = givenNames;
+            this.passportNumber = passportNumber;
+            this.dateOfBirth = dateOfBirth;
+            this.expiryDate = expiryDate;
+            this.requestId = requestId;
+            this.correlationId = correlationId;
+            this.dcsResponse = dcsResponse;
+        }
+
+        public String getFamilyName() {
+            return familyName;
+        }
+
+        public String[] getGivenNames() {
+            return givenNames;
+        }
+
+        public String getPassportNumber() {
+            return passportNumber;
+        }
+
+        public LocalDate getDateOfBirth() {
+            return dateOfBirth;
+        }
+
+        public LocalDate getExpiryDate() {
+            return expiryDate;
+        }
+
+        public UUID getRequestId() {
+            return requestId;
+        }
+
+        public UUID getCorrelationId() {
+            return correlationId;
+        }
+
+        public DcsResponse getDcsResponse() {
+            return dcsResponse;
+        }
+
+        public static class Builder {
+            private String familyName;
+            private String[] givenNames;
+            private String passportNumber;
+            private LocalDate dateOfBirth;
+            private LocalDate expiryDate;
+            private UUID requestId;
+            private UUID correlationId;
+            private DcsResponse dcsResponse;
+
+            public Builder setFamilyName(String familyName) {
+                this.familyName = familyName;
+                return this;
+            }
+
+            public Builder setGivenNames(String[] givenNames) {
+                this.givenNames = givenNames;
+                return this;
+            }
+
+            public Builder setPassportNumber(String passportNumber) {
+                this.passportNumber = passportNumber;
+                return this;
+            }
+
+            public Builder setDateOfBirth(LocalDate dateOfBirth) {
+                this.dateOfBirth = dateOfBirth;
+                return this;
+            }
+
+            public Builder setExpiryDate(LocalDate expiryDate) {
+                this.expiryDate = expiryDate;
+                return this;
+            }
+
+            public Builder setRequestId(UUID requestId) {
+                this.requestId = requestId;
+                return this;
+            }
+
+            public Builder setCorrelationId(UUID correlationId) {
+                this.correlationId = correlationId;
+                return this;
+            }
+
+            public Builder setDcsResponse(DcsResponse dcsResponse) {
+                this.dcsResponse = dcsResponse;
+                return this;
+            }
+
+            public Attributes build() {
+                return new Attributes(
+                        familyName,
+                        givenNames,
+                        passportNumber,
+                        dateOfBirth,
+                        expiryDate,
+                        requestId,
+                        correlationId,
+                        dcsResponse);
+            }
+        }
+    }
+}

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.dcscredential.domain.PassportCredentialIssuerResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -71,6 +72,7 @@ class DcsCredentialHandlerTest {
 
     @BeforeEach
     void setUp() {
+        attributes.setDcsResponse(validDcsResponse);
         dcsCredential =
                 new PassportCheckDao(TEST_RESOURCE_ID, attributes);
         responseBody = new HashMap<>();
@@ -111,13 +113,18 @@ class DcsCredentialHandlerTest {
 
         APIGatewayProxyResponseEvent response =
                 dcsCredentialHandler.handleRequest(event, mockContext);
-       PassportCheckDao responseBody =
-                objectMapper.readValue(response.getBody(), PassportCheckDao.class);
-
-        PassportAttributes attributes = responseBody.getAttributes();
+        PassportCredentialIssuerResponse responseBody =
+                objectMapper.readValue(response.getBody(), PassportCredentialIssuerResponse.class);
 
         assertEquals(dcsCredential.getResourceId(), responseBody.getResourceId());
-        assertEquals(objectMapper.writeValueAsString(dcsCredential), objectMapper.writeValueAsString(responseBody));
+        assertEquals(dcsCredential.getAttributes().getSurname(), responseBody.getAttributes().getFamilyName());
+        assertEquals(dcsCredential.getAttributes().getForenames()[0], responseBody.getAttributes().getGivenNames()[0]);
+        assertEquals(dcsCredential.getAttributes().getPassportNumber(), responseBody.getAttributes().getPassportNumber());
+        assertEquals(dcsCredential.getAttributes().getDateOfBirth(), responseBody.getAttributes().getDateOfBirth());
+        assertEquals(dcsCredential.getAttributes().getExpiryDate(), responseBody.getAttributes().getExpiryDate());
+        assertEquals(dcsCredential.getAttributes().getRequestId(), responseBody.getAttributes().getRequestId());
+        assertEquals(dcsCredential.getAttributes().getCorrelationId(), responseBody.getAttributes().getCorrelationId());
+        assertEquals(dcsCredential.getAttributes().getDcsResponse().getRequestId(), responseBody.getAttributes().getDcsResponse().getRequestId());
     }
 
     @Test

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.passport.dcscredential.domain;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PassportCredentialIssuerResponseTest {
+
+    public static final String FAMILY_NAME = "familyName";
+    public static final String[] GIVEN_NAMES = {"givenNames"};
+    public static final String PASSPORT_NUMBER = "passportNumber";
+    public static final LocalDate DATE_OF_BIRTH = LocalDate.now();
+    public static final LocalDate EXPIRY_DATE = LocalDate.now();
+    public static final String RESOURCE_ID = "resourceId";
+
+    @Test
+    void shouldConvertPassportCheckDaoToPassportCredentialIssuerResponse() {
+
+        PassportAttributes attributes = new PassportAttributes(PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
+        attributes.setDcsResponse(new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), true, false, new String[]{}));
+        PassportCheckDao passportCheckDao = new PassportCheckDao(RESOURCE_ID, attributes);
+
+        PassportCredentialIssuerResponse passportCredentialIssuerResponse = PassportCredentialIssuerResponse.fromPassportCheckDao(passportCheckDao);
+
+        assertEquals(RESOURCE_ID, passportCredentialIssuerResponse.getResourceId());
+        assertEquals(FAMILY_NAME, passportCredentialIssuerResponse.getAttributes().getFamilyName());
+        assertEquals(GIVEN_NAMES, passportCredentialIssuerResponse.getAttributes().getGivenNames());
+        assertEquals(PASSPORT_NUMBER, passportCredentialIssuerResponse.getAttributes().getPassportNumber());
+        assertEquals(DATE_OF_BIRTH, passportCredentialIssuerResponse.getAttributes().getDateOfBirth());
+        assertEquals(EXPIRY_DATE, passportCredentialIssuerResponse.getAttributes().getExpiryDate());
+        assertEquals(passportCheckDao.getAttributes().getRequestId(), passportCredentialIssuerResponse.getAttributes().getRequestId());
+        assertEquals(passportCheckDao.getAttributes().getCorrelationId(), passportCredentialIssuerResponse.getAttributes().getCorrelationId());
+        assertEquals(passportCheckDao.getAttributes().getDcsResponse(), passportCredentialIssuerResponse.getAttributes().getDcsResponse());
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportAttributesConverter.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportAttributesConverter.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Map;
 
 public class PassportAttributesConverter implements AttributeConverter<PassportAttributes> {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update DcsCredentialHandler to return PassportCredentialIssuerResponse that maps the DcsResponse to core's expected Credential format.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-638](https://govukverify.atlassian.net/browse/PYI-638)
