### PR TITLE
PYI-654: Update structure of the PassportCredentialIssuerResponse to match expected data structure

### DIFF
--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/Name.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/Name.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.passport.dcscredential.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Name {
+    @JsonProperty private final String familyName;
+    @JsonProperty private final String[] givenNames;
+
+    @JsonCreator
+    public Name(
+            @JsonProperty(value = "familyName", required = true) String familyName,
+            @JsonProperty(value = "givenNames", required = true) String[] givenNames) {
+        this.familyName = familyName;
+        this.givenNames = givenNames;
+    }
+
+    public String getFamilyName() {
+        return familyName;
+    }
+
+    public String[] getGivenNames() {
+        return givenNames;
+    }
+}

--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
@@ -24,8 +24,7 @@ public class PassportCredentialIssuerResponse {
             PassportCheckDao credential) {
         Attributes attributes =
                 new Attributes.Builder()
-                        .setFamilyName(credential.getAttributes().getSurname())
-                        .setGivenNames(credential.getAttributes().getForenames())
+                        .setNames(new Name(credential.getAttributes().getSurname(), credential.getAttributes().getForenames()))
                         .setPassportNumber(credential.getAttributes().getPassportNumber())
                         .setDateOfBirth(credential.getAttributes().getDateOfBirth())
                         .setExpiryDate(credential.getAttributes().getExpiryDate())
@@ -46,8 +45,7 @@ public class PassportCredentialIssuerResponse {
 
     public static class Attributes {
 
-        @JsonProperty private final String familyName;
-        @JsonProperty private final String[] givenNames;
+        @JsonProperty private final Name names;
         @JsonProperty private final String passportNumber;
         @JsonProperty private final LocalDate dateOfBirth;
         @JsonProperty private final LocalDate expiryDate;
@@ -57,16 +55,14 @@ public class PassportCredentialIssuerResponse {
 
         @JsonCreator
         public Attributes(
-                @JsonProperty(value = "familyName", required = true) String familyName,
-                @JsonProperty(value = "givenNames", required = true) String[] givenNames,
+                @JsonProperty(value = "names", required = true) Name names,
                 @JsonProperty(value = "passportNumber", required = true) String passportNumber,
                 @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
                 @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
                 @JsonProperty(value = "requestId", required = true) UUID requestId,
                 @JsonProperty(value = "correlationId", required = true) UUID correlationId,
                 @JsonProperty(value = "dcsResponse", required = true) DcsResponse dcsResponse) {
-            this.familyName = familyName;
-            this.givenNames = givenNames;
+            this.names = names;
             this.passportNumber = passportNumber;
             this.dateOfBirth = dateOfBirth;
             this.expiryDate = expiryDate;
@@ -75,12 +71,8 @@ public class PassportCredentialIssuerResponse {
             this.dcsResponse = dcsResponse;
         }
 
-        public String getFamilyName() {
-            return familyName;
-        }
-
-        public String[] getGivenNames() {
-            return givenNames;
+        public Name getNames() {
+            return names;
         }
 
         public String getPassportNumber() {
@@ -108,8 +100,7 @@ public class PassportCredentialIssuerResponse {
         }
 
         public static class Builder {
-            private String familyName;
-            private String[] givenNames;
+            private Name names;
             private String passportNumber;
             private LocalDate dateOfBirth;
             private LocalDate expiryDate;
@@ -117,13 +108,8 @@ public class PassportCredentialIssuerResponse {
             private UUID correlationId;
             private DcsResponse dcsResponse;
 
-            public Builder setFamilyName(String familyName) {
-                this.familyName = familyName;
-                return this;
-            }
-
-            public Builder setGivenNames(String[] givenNames) {
-                this.givenNames = givenNames;
+            public Builder setNames(Name names) {
+                this.names = names;
                 return this;
             }
 
@@ -159,8 +145,7 @@ public class PassportCredentialIssuerResponse {
 
             public Attributes build() {
                 return new Attributes(
-                        familyName,
-                        givenNames,
+                        names,
                         passportNumber,
                         dateOfBirth,
                         expiryDate,

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
@@ -117,8 +117,8 @@ class DcsCredentialHandlerTest {
                 objectMapper.readValue(response.getBody(), PassportCredentialIssuerResponse.class);
 
         assertEquals(dcsCredential.getResourceId(), responseBody.getResourceId());
-        assertEquals(dcsCredential.getAttributes().getSurname(), responseBody.getAttributes().getFamilyName());
-        assertEquals(dcsCredential.getAttributes().getForenames()[0], responseBody.getAttributes().getGivenNames()[0]);
+        assertEquals(dcsCredential.getAttributes().getSurname(), responseBody.getAttributes().getNames().getFamilyName());
+        assertEquals(dcsCredential.getAttributes().getForenames()[0], responseBody.getAttributes().getNames().getGivenNames()[0]);
         assertEquals(dcsCredential.getAttributes().getPassportNumber(), responseBody.getAttributes().getPassportNumber());
         assertEquals(dcsCredential.getAttributes().getDateOfBirth(), responseBody.getAttributes().getDateOfBirth());
         assertEquals(dcsCredential.getAttributes().getExpiryDate(), responseBody.getAttributes().getExpiryDate());

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
@@ -29,8 +29,8 @@ class PassportCredentialIssuerResponseTest {
         PassportCredentialIssuerResponse passportCredentialIssuerResponse = PassportCredentialIssuerResponse.fromPassportCheckDao(passportCheckDao);
 
         assertEquals(RESOURCE_ID, passportCredentialIssuerResponse.getResourceId());
-        assertEquals(FAMILY_NAME, passportCredentialIssuerResponse.getAttributes().getFamilyName());
-        assertEquals(GIVEN_NAMES, passportCredentialIssuerResponse.getAttributes().getGivenNames());
+        assertEquals(FAMILY_NAME, passportCredentialIssuerResponse.getAttributes().getNames().getFamilyName());
+        assertEquals(GIVEN_NAMES, passportCredentialIssuerResponse.getAttributes().getNames().getGivenNames());
         assertEquals(PASSPORT_NUMBER, passportCredentialIssuerResponse.getAttributes().getPassportNumber());
         assertEquals(DATE_OF_BIRTH, passportCredentialIssuerResponse.getAttributes().getDateOfBirth());
         assertEquals(EXPIRY_DATE, passportCredentialIssuerResponse.getAttributes().getExpiryDate());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update PassportCredentialIssuerResponse object to now store all of the 'familyName' and 'givenNames' properties within a 'names' object.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To match our expected data structure from core-back and to fix the shared attributes requests.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-654](https://govukverify.atlassian.net/browse/PYI-654)
