### PR TITLE
BAU: Fix slash for cred issuer config param

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -135,7 +135,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "${Environment}/credentialIssuers/ukPassport/clients/"
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${Environment}/credentialIssuers/ukPassport/clients/*"

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -195,7 +195,7 @@ public class ConfigurationService {
     }
 
     public Certificate getClientJwtSigningCert(String clientId) throws CertificateException {
-        return getCertificateFromStore(String.format(System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX") + "%s/sharedAttributesJwtSigningCert", clientId));
+        return getCertificateFromStore(String.format(System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX") + "/%s/sharedAttributesJwtSigningCert", clientId));
     }
 
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a missing slash at the beginning of the param.

It also removes the trailing slash to avoid an issue found with getting
multiple values using the prefix. This was not an issue here but it's
good to be consistant.
