### PR TITLE
PYI-656: generate gpg45 score for the dcs passport credentials

### DIFF
--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
@@ -18,7 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.dcscredential.domain.PassportCredentialIssuerResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.Gpg45Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 import uk.gov.di.ipv.cri.passport.library.service.AccessTokenService;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
@@ -70,11 +72,13 @@ class DcsCredentialHandlerTest {
                     LocalDate.parse(DATE_OF_BIRTH),
                     LocalDate.parse(EXPIRY_DATE));
 
+    private final PassportGpg45Score gpg45Score = new PassportGpg45Score(new Gpg45Evidence(4, 4));
+
     @BeforeEach
     void setUp() {
         attributes.setDcsResponse(validDcsResponse);
         dcsCredential =
-                new PassportCheckDao(TEST_RESOURCE_ID, attributes);
+                new PassportCheckDao(TEST_RESOURCE_ID, attributes, gpg45Score);
         responseBody = new HashMap<>();
 
         dcsCredentialHandler =

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponseTest.java
@@ -2,7 +2,9 @@ package uk.gov.di.ipv.cri.passport.dcscredential.domain;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.Gpg45Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 
 import java.time.LocalDate;
@@ -23,8 +25,9 @@ class PassportCredentialIssuerResponseTest {
     void shouldConvertPassportCheckDaoToPassportCredentialIssuerResponse() {
 
         PassportAttributes attributes = new PassportAttributes(PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
+        PassportGpg45Score gpg45Score = new PassportGpg45Score(new Gpg45Evidence(4, 4));
         attributes.setDcsResponse(new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), true, false, new String[]{}));
-        PassportCheckDao passportCheckDao = new PassportCheckDao(RESOURCE_ID, attributes);
+        PassportCheckDao passportCheckDao = new PassportCheckDao(RESOURCE_ID, attributes, gpg45Score);
 
         PassportCredentialIssuerResponse passportCredentialIssuerResponse = PassportCredentialIssuerResponse.fromPassportCheckDao(passportCheckDao);
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Gpg45Evidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/Gpg45Evidence.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.cri.passport.library.domain;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+public class Gpg45Evidence {
+    private final int strength;
+    private final int validity;
+
+    public Gpg45Evidence(int strength, int validity) {
+        this.strength = strength;
+        this.validity = validity;
+    }
+
+    public int getStrength() {
+        return strength;
+    }
+
+    public int getValidity() {
+        return validity;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/PassportGpg45Score.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/PassportGpg45Score.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.passport.library.domain;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.Gpg45EvidenceConverter;
+
+@DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
+public class PassportGpg45Score {
+    private final Gpg45Evidence evidence;
+
+    public PassportGpg45Score(Gpg45Evidence evidence) {
+        this.evidence = evidence;
+    }
+
+    @DynamoDbConvertedBy(Gpg45EvidenceConverter.class)
+    public Gpg45Evidence getEvidence() {
+        return evidence;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/Gpg45EvidenceConverter.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/Gpg45EvidenceConverter.java
@@ -1,0 +1,42 @@
+package uk.gov.di.ipv.cri.passport.library.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.domain.Gpg45Evidence;
+
+import java.util.Map;
+
+@ExcludeFromGeneratedCoverageReport
+public class Gpg45EvidenceConverter implements AttributeConverter<Gpg45Evidence> {
+    @Override
+    public AttributeValue transformFrom(Gpg45Evidence input) {
+        Map<String, AttributeValue> attributeValueMap =
+                Map.of(
+                        "strength",
+                        AttributeValue.builder().s(Integer.toString(input.getStrength())).build(),
+                        "validity", AttributeValue.builder().s(Integer.toString(input.getValidity())).build());
+
+        return AttributeValue.builder().m(attributeValueMap).build();
+    }
+
+    @Override
+    public Gpg45Evidence transformTo(AttributeValue input) {
+        Map<String, AttributeValue> attributeMap = input.m();
+        return new Gpg45Evidence(
+                Integer.parseInt(attributeMap.get("strength").s()),
+                Integer.parseInt(attributeMap.get("validity").s()));
+    }
+
+    @Override
+    public EnhancedType<Gpg45Evidence> type() {
+        return EnhancedType.of(Gpg45Evidence.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 
 @DynamoDbBean
 public class PassportCheckDao {
@@ -14,12 +15,16 @@ public class PassportCheckDao {
     @DynamoDBAttribute(attributeName = "attributes")
     private PassportAttributes attributes;
 
+    @DynamoDBAttribute(attributeName = "gpg45Score")
+    private PassportGpg45Score gpg45Score;
+
     public PassportCheckDao() {}
 
     public PassportCheckDao(
-            String resourceId, PassportAttributes attributes) {
+            String resourceId, PassportAttributes attributes, PassportGpg45Score gpg45Score) {
         this.resourceId = resourceId;
         this.attributes = attributes;
+        this.gpg45Score = gpg45Score;
     }
 
     @DynamoDbPartitionKey
@@ -34,6 +39,11 @@ public class PassportCheckDao {
     @DynamoDbConvertedBy(PassportAttributesConverter.class)
     public PassportAttributes getAttributes() {
         return attributes;
+    }
+
+    @DynamoDbConvertedBy(PassportGpg45ScoreConverter.class)
+    public PassportGpg45Score getGpg45Score() {
+        return gpg45Score;
     }
 
     public void setAttributes(PassportAttributes passportAttributes) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportGpg45ScoreConverter.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportGpg45ScoreConverter.java
@@ -1,0 +1,48 @@
+package uk.gov.di.ipv.cri.passport.library.persistence.item;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.domain.Gpg45Evidence;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
+
+import java.util.Map;
+
+@ExcludeFromGeneratedCoverageReport
+public class PassportGpg45ScoreConverter implements AttributeConverter<PassportGpg45Score> {
+    ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public AttributeValue transformFrom(PassportGpg45Score input) {
+        Map<String, AttributeValue> attributeValueMap =
+                Map.of(
+                        "evidence",
+                        AttributeValue.builder().m(objectMapper.convertValue(input.getEvidence(), new TypeReference<Map<String, AttributeValue>>() {
+                        })).build());
+
+        return AttributeValue.builder().m(attributeValueMap).build();
+    }
+
+    @Override
+    public PassportGpg45Score transformTo(AttributeValue input) {
+        Map<String, AttributeValue> attributeMap = input.m();
+
+        Map<String, AttributeValue> evidenceMap = attributeMap.get("evidence").m();
+        Gpg45Evidence evidence = new Gpg45Evidence(Integer.parseInt(evidenceMap.get("strength").s()), Integer.parseInt(evidenceMap.get("validity").s()));
+
+        return new PassportGpg45Score(evidence);
+    }
+
+    @Override
+    public EnhancedType<PassportGpg45Score> type() {
+        return EnhancedType.of(PassportGpg45Score.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.M;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCredentialServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCredentialServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 
@@ -26,6 +27,9 @@ class DcsCredentialServiceTest {
     @Mock
     PassportAttributes passportAttributes;
 
+    @Mock
+    PassportGpg45Score gpg45Score;
+
     @Mock DcsResponse dcsResponse;
 
     private DcsCredentialService dcsCredentialService;
@@ -39,7 +43,9 @@ class DcsCredentialServiceTest {
     void shouldReturnCredentialsFromDataStore() {
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(
-                        UUID.randomUUID().toString(), passportAttributes);
+                        UUID.randomUUID().toString(),
+                        passportAttributes,
+                        gpg45Score);
 
         when(mockDataStore.getItem(anyString())).thenReturn(passportCheckDao);
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -18,7 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.Gpg45Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 import uk.gov.di.ipv.cri.passport.library.exceptions.EmptyDcsResponseException;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -124,8 +126,9 @@ class PassportServiceTest {
                         new String[] {"FORENAMES"},
                         LocalDate.now(),
                         LocalDate.now());
+        PassportGpg45Score gpg45Score = new PassportGpg45Score(new Gpg45Evidence(4, 4));
         PassportCheckDao dcsResponse =
-                new PassportCheckDao("UUID", passportAttributes);
+                new PassportCheckDao("UUID", passportAttributes, gpg45Score);
         underTest.persistDcsResponse(dcsResponse);
         verify(dataStore).create(dcsResponse);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Generate a GPG45 score for a DCS passport evidence check.
- Sets strength score of 4
- Sets validity score of either 0 or 4 depending on the result of the dcsResponse valid value

Adds new aws DynamoDb converters to handle the conversion when writing and reading from DynamoDb.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The DCS passport cri should always return a evidence gpg45 score that is based off the result of the dcsResponse.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-656](https://govukverify.atlassian.net/browse/PYI-656)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
