### PR TITLE
PYI-656: Update gpg45 score values

### DIFF
--- a/lambdas/passport/src/main/java/uk/gov/di/ipv/cri/passport/passport/PassportHandler.java
+++ b/lambdas/passport/src/main/java/uk/gov/di/ipv/cri/passport/passport/PassportHandler.java
@@ -50,8 +50,9 @@ public class PassportHandler
     private static final Logger LOGGER = LoggerFactory.getLogger(PassportHandler.class);
     private static final ObjectMapper objectMapper =
             new ObjectMapper().registerModule(new JavaTimeModule());
-    private static final int MAX_GPG45_VALUE = 4;
-    private static final int MIN_GPG45_VALUE = 0;
+    private static final int MAX_PASSPORT_GPG45_STRENGTH_VALUE = 4;
+    private static final int MAX_PASSPORT_GPG45_VALIDITY_VALUE = 2;
+    private static final int MIN_PASSPORT_GPG45_VALUE = 0;
 
     public static final String AUTHORIZATION_CODE = "code";
 
@@ -148,8 +149,8 @@ public class PassportHandler
     }
 
     private PassportGpg45Score generateGpg45Score(DcsResponse dcsResponse) {
-        int validity = dcsResponse.isValid() ? MAX_GPG45_VALUE : MIN_GPG45_VALUE;
-        Gpg45Evidence gpg45Evidence = new Gpg45Evidence(MAX_GPG45_VALUE, validity);
+        int validity = dcsResponse.isValid() ? MAX_PASSPORT_GPG45_VALIDITY_VALUE : MIN_PASSPORT_GPG45_VALUE;
+        Gpg45Evidence gpg45Evidence = new Gpg45Evidence(MAX_PASSPORT_GPG45_STRENGTH_VALUE, validity);
 
         return new PassportGpg45Score(gpg45Evidence);
     }

--- a/lambdas/passport/src/test/java/uk/gov/di/ipv/cri/passport/passport/PassportHandlerTest.java
+++ b/lambdas/passport/src/test/java/uk/gov/di/ipv/cri/passport/passport/PassportHandlerTest.java
@@ -54,7 +54,7 @@ class PassportHandlerTest {
     public static final String[] FORENAMES = {"Tubbs"};
     public static final String DATE_OF_BIRTH = "1984-09-28";
     public static final String EXPIRY_DATE = "2024-09-03";
-    public static final Gpg45Evidence VALID_GPG45_SCORE = new Gpg45Evidence(4, 4);
+    public static final Gpg45Evidence VALID_GPG45_SCORE = new Gpg45Evidence(4, 2);
     public static final Gpg45Evidence INVALID_GPG45_SCORE = new Gpg45Evidence(4, 0);
 
     private final ObjectMapper objectMapper =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the max validity score to be 2.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
For the passport gpg45 score the evidence strength should be 4, and the validity is either 0 or 2 depending on the result of the DCS response.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-656](https://govukverify.atlassian.net/browse/PYI-656)

