### PR TITLE
PYI-682: Update the returned passport credential to include the new gpg45Score field

### DIFF
--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.passport.dcscredential.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 
 import java.time.LocalDate;
@@ -10,14 +11,17 @@ import java.util.UUID;
 
 public class PassportCredentialIssuerResponse {
 
-    @JsonProperty private Attributes attributes;
     @JsonProperty private String resourceId;
+    @JsonProperty private Attributes attributes;
+    @JsonProperty private PassportGpg45Score gpg45Score;
 
     public PassportCredentialIssuerResponse() {}
 
-    public PassportCredentialIssuerResponse(String resourceId, Attributes attributes) {
+    public PassportCredentialIssuerResponse(
+            String resourceId, Attributes attributes, PassportGpg45Score gpg45Score) {
         this.resourceId = resourceId;
         this.attributes = attributes;
+        this.gpg45Score = gpg45Score;
     }
 
     public static PassportCredentialIssuerResponse fromPassportCheckDao(
@@ -35,15 +39,20 @@ public class PassportCredentialIssuerResponse {
                         .setCorrelationId(credential.getAttributes().getCorrelationId())
                         .setDcsResponse(credential.getAttributes().getDcsResponse())
                         .build();
-        return new PassportCredentialIssuerResponse(credential.getResourceId(), attributes);
+        return new PassportCredentialIssuerResponse(
+                credential.getResourceId(), attributes, credential.getGpg45Score());
+    }
+
+    public String getResourceId() {
+        return resourceId;
     }
 
     public Attributes getAttributes() {
         return attributes;
     }
 
-    public String getResourceId() {
-        return resourceId;
+    public PassportGpg45Score getGpg45Score() {
+        return gpg45Score;
     }
 
     public static class Attributes {

--- a/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
+++ b/lambdas/dcscredential/src/test/java/uk/gov/di/ipv/cri/passport/dcscredential/DcsCredentialHandlerTest.java
@@ -146,6 +146,12 @@ class DcsCredentialHandlerTest {
         assertEquals(
                 dcsCredential.getAttributes().getDcsResponse().getRequestId(),
                 responseBody.getAttributes().getDcsResponse().getRequestId());
+        assertEquals(
+                dcsCredential.getGpg45Score().getEvidence().getStrength(),
+                responseBody.getGpg45Score().getEvidence().getStrength());
+        assertEquals(
+                dcsCredential.getGpg45Score().getEvidence().getValidity(),
+                responseBody.getGpg45Score().getEvidence().getValidity());
     }
 
     @Test


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated PassportCredentialIssuerResponse class to include the new gpg45Score field.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The DcsHandler lambda constructs a PassportCredentialIssuerResponse object based on the current DcsResponse stored in DynamoDB to be the returned passport credential. This PR includes the new gpg45Score field in that credential to be used and displayed within ipv-core.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-682](https://govukverify.atlassian.net/browse/PYI-682)

