### PR TITLE
PYI-688 Correct serialization of LocalDate in Credential Response

### DIFF
--- a/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
+++ b/lambdas/dcscredential/src/main/java/uk/gov/di/ipv/cri/passport/dcscredential/domain/PassportCredentialIssuerResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.passport.dcscredential.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.PassportGpg45Score;
@@ -59,8 +60,15 @@ public class PassportCredentialIssuerResponse {
 
         @JsonProperty private final Name names;
         @JsonProperty private final String passportNumber;
-        @JsonProperty private final LocalDate dateOfBirth;
-        @JsonProperty private final LocalDate expiryDate;
+
+        @JsonProperty
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private final LocalDate dateOfBirth;
+
+        @JsonProperty
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private final LocalDate expiryDate;
+
         @JsonProperty private final UUID requestId;
         @JsonProperty private final UUID correlationId;
         @JsonProperty private final DcsResponse dcsResponse;


### PR DESCRIPTION
[PYI-688] The ObjectMapper by default serializes LocalDate to an array of year,
month, day but we want to keep it as a string with format `yyyy-MM-dd`
to follow the ISO 8601 standard.

## Proposed changes
Format the LocalDates as strings of "yyyy-MM-dd"

### What changed

Add Jackson annotations so the ObjectMapper maps it as we want it to.

### Why did it change

Because expiry date and birth date were being returned as [YYYY, MM, d] in the json response.

### Issue tracking


- [PYI-688](https://govukverify.atlassian.net/browse/PYI-688)

## Checklists


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
