### PR TITLE
BAU Extend Exception rather than Throwable

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpResponseExceptionWithErrorBody.java
@@ -4,7 +4,7 @@ import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 
 import java.util.Map;
 
-public class HttpResponseExceptionWithErrorBody extends Throwable {
+public class HttpResponseExceptionWithErrorBody extends Exception {
     private final int statusCode;
     private final ErrorResponse errorResponse;
 


### PR DESCRIPTION
Better that the `HttpResponseExceptionWithErrorBody` custom exception
extends Exception rather than Throwable to follow convention.

