### PR TITLE
BAU: Remove Optional from config service and fix code smells

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpClientException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpClientException.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.cri.passport.library.exceptions;
+
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class HttpClientException extends RuntimeException {
+    public HttpClientException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/HttpClientSetUp.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/HttpClientSetUp.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.passport.library.helpers;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
+import uk.gov.di.ipv.cri.passport.library.exceptions.HttpClientException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
 import javax.net.ssl.SSLContext;
@@ -50,7 +51,7 @@ public class HttpClientSetUp {
                 | KeyManagementException
                 | KeyStoreException
                 | UnrecoverableKeyException e) {
-            throw new RuntimeException(e);
+            throw new HttpClientException(e);
         }
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -205,23 +205,14 @@ public class ConfigurationService {
     }
 
     public List<String> getClientRedirectUrls(String clientId) throws UnknownClientException {
-        Optional<String> redirectUrlStrings =
-                Optional.ofNullable(
-                        ssmProvider.get(
-                                String.format(
-                                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                                + "/%s/jwtAuthentication/validRedirectUrls",
-                                        clientId)));
+        String redirectUrlStrings =
+                ssmProvider.get(
+                        String.format(
+                                System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
+                                        + "/%s/jwtAuthentication/validRedirectUrls",
+                                clientId));
 
-        return Arrays.asList(
-                redirectUrlStrings
-                        .orElseThrow(
-                                () ->
-                                        new UnknownClientException(
-                                                String.format(
-                                                        "Client redirect URLs are not set in parameter store for client ID '%s'",
-                                                        clientId)))
-                        .split(CLIENT_REDIRECT_URL_SEPARATOR));
+        return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
 
     public String getAudienceForClients() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -33,6 +33,8 @@ public class ConfigurationService {
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
     private static final String IS_LOCAL = "IS_LOCAL";
     private static final String CLIENT_REDIRECT_URL_SEPARATOR = ",";
+    public static final String CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX =
+            "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX";
 
     private final SSMProvider ssmProvider;
 
@@ -199,18 +201,16 @@ public class ConfigurationService {
     public Certificate getClientJwtSigningCert(String clientId) throws CertificateException {
         return getCertificateFromStore(
                 String.format(
-                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                + "/%s/sharedAttributesJwtSigningCert",
-                        clientId));
+                        "%s/%s/sharedAttributesJwtSigningCert",
+                        System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 
     public List<String> getClientRedirectUrls(String clientId) throws UnknownClientException {
         String redirectUrlStrings =
                 ssmProvider.get(
                         String.format(
-                                System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                        + "/%s/jwtAuthentication/validRedirectUrls",
-                                clientId));
+                                "%s/%s/jwtAuthentication/validRedirectUrls",
+                                System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
 
         return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
@@ -222,17 +222,15 @@ public class ConfigurationService {
     public Certificate getClientCertificate(String clientId) throws CertificateException {
         return getCertificateFromStore(
                 String.format(
-                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                + "/%s/jwtAuthentication/publicCertificateForCoreToVerify",
-                        clientId));
+                        "%s/%s/jwtAuthentication/publicCertificateForCoreToVerify",
+                        System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 
     public String getClientAuthenticationMethod(String clientId) {
         return ssmProvider.get(
                 String.format(
-                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                + "/%s/jwtAuthentication/authenticationMethod",
-                        clientId));
+                        "%s/%s/jwtAuthentication/authenticationMethod",
+                        System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 
     public String getMaxClientAuthTokenTtl() {


### PR DESCRIPTION
### Why did it change

#### [BAU: Remove Optional from config service](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/86/commits/3649af2f019ddf9b63bfb0107ae79b8ac8d097db) 
[3649af2](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/86/commits/3649af2f019ddf9b63bfb0107ae79b8ac8d097db)
The ssmProvider will throw a ParameterNotFound runtime exception rather
than returning null, so the use of the optional is unnecessary.

#### [BAU: Fix sonarcloud code smells](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/86/commits/13cb14b5864f9fc5637eba0bf175238eb17a9486) 
[13cb14b](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/86/commits/13cb14b5864f9fc5637eba0bf175238eb17a9486)

* Throw custom exception in http client setup. We shouldn't be throwing generic exceptions like RuntimeExceptions.
* Use format specifiers instead of string concatenation
* Refactor env string to constant


