### PR TITLE
BAU: Fix ssm path name for passport cri public cert name

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -222,7 +222,7 @@ public class ConfigurationService {
     public Certificate getClientCertificate(String clientId) throws CertificateException {
         return getCertificateFromStore(
                 String.format(
-                        "%s/%s/jwtAuthentication/publicCertificateForCoreToVerify",
+                        "%s/%s/jwtAuthentication/publicCertificateToVerify",
                         System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated name of SSM param for the passport public cert used for signature verification to match the value in config.
<!-- Describe the changes in detail - the "what"-->

