### PR TITLE
PYI-726 Correct SSM Permissions for DCS Auth Lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -72,6 +72,14 @@ Resources:
             TableName: !Ref CRIPassportAuthCodesTable
         - DynamoDBCrudPolicy:
             TableName: !Ref CRIPassportAccessTokensTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/audienceForClients
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients/*
       Events:
         IPVCriUKPassportAPI:
           Type: Api


### PR DESCRIPTION
## Proposed changes
Grant the DCS auth lambda permission to access the necessary SSM Parameters.

### Issue tracking
- [PYI-726](https://govukverify.atlassian.net/browse/PYI-726)