### PR TITLE
PYI-727: Retrieve the query param values from the request body instead of request url

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -75,7 +75,7 @@ public class AccessTokenHandler
                         validationResult.getError().toJSONObject());
             }
 
-            tokenRequestValidator.authenticateClient(input.getBody(), input.getPathParameters());
+            tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeGrant authorizationCodeGrant =
                     (AuthorizationCodeGrant) tokenRequest.getAuthorizationGrant();

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidator.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.accesstoken.domain.ConfigurationServicePublicKeySelector;
 import uk.gov.di.ipv.cri.passport.accesstoken.exceptions.ClientAuthenticationException;
+import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
 import java.time.OffsetDateTime;
@@ -34,8 +35,8 @@ public class TokenRequestValidator {
         this.verifier = getClientAuthVerifier(configurationService);
     }
 
-    public void authenticateClient(String requestBody, Map<String, String> queryParams)
-            throws ClientAuthenticationException {
+    public void authenticateClient(String requestBody) throws ClientAuthenticationException {
+        Map<String, String> queryParams = RequestHelper.parseRequestBody(requestBody);
         if (queryParams.containsKey(CLIENT_ASSERTION_PARAM)) {
             authenticateClientWithJwt(requestBody);
         } else {

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -207,7 +207,7 @@ class AccessTokenHandlerTest {
 
         doThrow(new ClientAuthenticationException("error"))
                 .when(mockTokenRequestValidator)
-                .authenticateClient(any(), any());
+                .authenticateClient(any());
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidatorTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidatorTest.java
@@ -77,8 +77,7 @@ class TokenRequestValidatorTest {
                 getValidQueryParams(generateClientAssertion(getValidClaimsSetValues()));
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(
-                            queryMapToString(validQueryParams), validQueryParams);
+                    validator.authenticateClient(queryMapToString(validQueryParams));
                 });
     }
 
@@ -100,8 +99,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(invalidSignatureQueryParams),
-                                    invalidSignatureQueryParams);
+                                    queryMapToString(invalidSignatureQueryParams));
                         });
 
         assertTrue(exception.getMessage().contains("InvalidClientException: Bad JWT signature"));
@@ -121,8 +119,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(differentIssuerAndSubjectQueryParams),
-                                    differentIssuerAndSubjectQueryParams);
+                                    queryMapToString(differentIssuerAndSubjectQueryParams));
                         });
 
         assertTrue(
@@ -147,8 +144,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(wrongAudienceQueryParams),
-                                    wrongAudienceQueryParams);
+                                    queryMapToString(wrongAudienceQueryParams));
                         });
 
         assertTrue(
@@ -173,8 +169,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(expiredQueryParams), expiredQueryParams);
+                            validator.authenticateClient(queryMapToString(expiredQueryParams));
                         });
 
         assertTrue(exception.getMessage().contains("Expired JWT"));
@@ -199,8 +194,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(expiredQueryParams), expiredQueryParams);
+                            validator.authenticateClient(queryMapToString(expiredQueryParams));
                         });
         assertTrue(
                 exception
@@ -216,7 +210,7 @@ class TokenRequestValidatorTest {
 
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(queryMapToString(params), params);
+                    validator.authenticateClient(queryMapToString(params));
                 });
     }
 
@@ -229,8 +223,7 @@ class TokenRequestValidatorTest {
 
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(
-                            queryMapToString(validQueryParams), validQueryParams);
+                    validator.authenticateClient(queryMapToString(validQueryParams));
                 });
     }
 
@@ -246,8 +239,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(missingClientAssertionParams),
-                                    missingClientAssertionParams);
+                                    queryMapToString(missingClientAssertionParams));
                         });
 
         assertEquals(
@@ -263,8 +255,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(missingClientIdParams), missingClientIdParams);
+                            validator.authenticateClient(queryMapToString(missingClientIdParams));
                         });
 
         assertEquals(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelper.java
@@ -1,7 +1,11 @@
 package uk.gov.di.ipv.cri.passport.library.helpers;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 
+import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -26,5 +30,15 @@ public class RequestHelper {
             }
         }
         return null;
+    }
+
+    public static Map<String, String> parseRequestBody(String body) {
+        Map<String, String> queryPairs = new HashMap<>();
+
+        for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {
+            queryPairs.put(pair.getName(), pair.getValue());
+        }
+
+        return queryPairs;
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Retrieve the client auth params from the request body instead of the url params. Add new RequestHelper method that can parse the params into a map to be used during validation.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The client auth param values are passed in through a form-url-encoded body. Currently the wrong method was used to retrieve these as url query params causing null pointers.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-727](https://govukverify.atlassian.net/browse/PYI-727)
