### PR TITLE
BAU: Expect sharedAttribute values in vc_http_api claim

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -22,7 +22,8 @@ public enum ErrorResponse {
     JWT_SIGNATURE_IS_INVALID(1013, "Signature of the shared attribute JWT is invalid"),
     INVALID_REDIRECT_URL(1014, "Provided redirect URL is not in those configured for client"),
     UNKNOWN_CLIENT_ID(1015, "Unknown client id provided in request params"),
-    INVALID_REQUEST_PARAM(1016, "Invalid request param");
+    INVALID_REQUEST_PARAM(1016, "Invalid request param"),
+    VC_HTTP_API_CLAIM_MISSING(1017, "vc_http_api claim missing from shared attribute JWT");
 
     private final int code;
     private final String message;


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Expect sharedAttribute values in vc_http_api claim

### Why did it change

In [RFC 0008](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0008-identity-ipv-sequence-diagram.md#authorize)
we stipulate that the shared attributes will be encapsulated in a top
level claim in the JWT called vc_http_api.

The KBV team has implemented this, and we should probably do the same
thing.

core-back has been updated to use this top level claim in [PR 154](https://github.com/alphagov/di-ipv-core-back/pull/154)
