### PR TITLE
BAU: Expect vc_http_api claim in a claims claim

### DIFF
--- a/lambdas/jwtverification/src/main/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandler.java
+++ b/lambdas/jwtverification/src/main/java/uk/gov/di/ipv/cri/passport/jwtverification/JwtVerificationHandler.java
@@ -28,6 +28,7 @@ public class JwtVerificationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     public static final String VC_HTTP_API_CLAIM = "vc_http_api";
+    public static final String CLAIMS_CLAIM = "claims";
     private final ConfigurationService configurationService;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JwtVerificationHandler.class);
@@ -71,15 +72,15 @@ public class JwtVerificationHandler
             }
 
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-            Map<String, Object> sharedAttributes = claimsSet.getJSONObjectClaim(VC_HTTP_API_CLAIM);
+            Map<String, Object> claims = claimsSet.getJSONObjectClaim(CLAIMS_CLAIM);
 
-            if (sharedAttributes == null) {
+            if (claims == null || claims.get(VC_HTTP_API_CLAIM) == null) {
                 LOGGER.error("vc_http_api claim not found in JWT");
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         BAD_REQUEST, ErrorResponse.VC_HTTP_API_CLAIM_MISSING);
             }
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(OK, sharedAttributes);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(OK, claims.get(VC_HTTP_API_CLAIM));
         } catch (ParseException e) {
             LOGGER.error("Failed to parse the shared attributes JWT", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
**Companion PR on core-back here: https://github.com/alphagov/di-ipv-core-back/pull/155**
## Proposed changes

### What changed

RFC 0008 actually specifies that the custom vc_http_api claim should be
nested under a top level claim in the JWT called `claims`.

This is to keep in line with the OIDC spec which we're sort of following.
https://openid.net/specs/openid-connect-core-1_0.html#RequestObject


### Why did it change

To meet the spec we've laid out.
