### PR TITLE
PYIC-861: Add passport VC issuer config

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,6 +34,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           DCS_RESPONSE_TABLE_NAME: !Select [1, !Split ['/', !GetAtt DCSResponseTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
+          VERIFIABLE_CREDENTIAL_ISSUER_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialIssuer"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref DCSResponseTable

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -233,6 +233,10 @@ public class ConfigurationService {
                         System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 
+    public String getVerifiableCredentialIssuer() {
+        return getParameterFromStoreUsingEnv("VERIFIABLE_CREDENTIAL_ISSUER_PARAM");
+    }
+
     public String getMaxClientAuthTokenTtl() {
         return getParameterFromStoreUsingEnv("PASSPORT_CRI_CLIENT_AUTH_MAX_TTL");
     }


### PR DESCRIPTION
**PR to create the values being referenced here in the param store: https://github.com/alphagov/di-ipv-config/pull/269**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Why did it change

We need to provide a value for the issuer when generating VCs. This
should come from config. It must be a URL. Initially we’ll set it to the
host of the passport CRI.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-861](https://govukverify.atlassian.net/browse/PYI-861)
