### PR TITLE
BAU: Set Java tiered compilation level

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -5,6 +5,9 @@ Description: ipv-cri-uk-passport-back
 Globals:
   Function:
     Timeout: 40
+    Environment:
+      Variables:
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
 
 Parameters:
   Environment:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set Java tiered compilation level

### Why did it change

Mark Sailes released a blog post describing how you can reduce cold
start times by setting the Java tiered compilation level. Setting this
global will make the change to all our passport-back lambdas.

For more details on what this does here's the blog post:
https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
