### PR TITLE
PYIC-889: Run integration tests in Github workflows

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -43,6 +43,11 @@ jobs:
           role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
+      - name: Integration tests
+        env:
+          DCS_RESPONSE_TABLE_NAME: dcs-response-build
+        run: ./gradlew intTest
+
       - name: SAM validate
         working-directory: ./deploy
         run: sam validate

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -11,28 +11,48 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@v2
+        -
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: gradle
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
       - name: Cache Gradle packages
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Build
+
+      - name: Build and unit tests
         run: ./gradlew clean build
+
+      - name: Set up AWS creds for integration tests
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Integration tests
+        env:
+          DCS_RESPONSE_TABLE_NAME: dcs-response-build
+        run: ./gradlew intTest
+
       - name: Perform Static Analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -2,9 +2,11 @@
 name: gradle test and build
 
 on:
-
+  push:
+    branches:
+      - main
   pull_request:
-    branches: main
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -17,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        -
+
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
**AWS perms PR here: https://github.com/alphagov/di-ipv-config/pull/302**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Run integration tests in Github workflows

### Why did it change

We want to run the integration tests as part of our Github workflows. To
do this Github actions will need to talk to DynamoDB in the build
account.

We already have a Github OIDC provider deployed in AWS which we use to
put build artefacts into S3. We can use the same patten to access
DynamoDB. A separate PR has been raised on the config dir to give the
AWS role perms to talk to DynamoDB.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-889](https://govukverify.atlassian.net/browse/PYI-889)
