### PR TITLE
Bau fix passport cri evidence structure

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -114,7 +114,12 @@ public class DateStorePassportCheckIT {
     private PassportCheckDao createPassportCheckDao() {
         String resourceId = UUID.randomUUID().toString();
         DcsResponse dcsResponse =
-                new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
+                new DcsResponse(
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
+                        false,
+                        true,
+                        null);
         PassportAttributes passportAttributes =
                 new PassportAttributes(
                         "passport-number",

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -77,10 +77,12 @@ class AuthorizationCodeHandlerTest {
                     "expiryDate", EXPIRY_DATE);
 
     private final DcsResponse validDcsResponse =
-            new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
+            new DcsResponse(
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(), false, true, null);
 
     private final DcsResponse invalidDcsResponse =
-            new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, false, null);
+            new DcsResponse(
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(), false, false, null);
 
     @Mock Context context;
     @Mock PassportService passportService;
@@ -272,8 +274,8 @@ class AuthorizationCodeHandlerTest {
 
         DcsResponse errorDcsResponse =
                 new DcsResponse(
-                        UUID.randomUUID(),
-                        UUID.randomUUID(),
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
                         true,
                         false,
                         List.of("Test DCS error message"));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -28,6 +30,7 @@ import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.DcsPassportCheckService;
 
 import java.time.Instant;
+import java.util.Map;
 
 import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
@@ -138,6 +141,7 @@ public class IssueCredentialHandler
 
     private SignedJWT generateAndSignVerifiableCredentialJwt(
             VerifiableCredential verifiableCredential, String subject) throws JOSEException {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         Instant now = Instant.now();
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -153,7 +157,7 @@ public class IssueCredentialHandler
                                 new String[] {
                                     VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
                                 })
-                        .claim(VC_CLAIM, verifiableCredential)
+                        .claim(VC_CLAIM, mapper.convertValue(verifiableCredential, Map.class))
                         .build();
 
         return JwtHelper.createSignedJwtFromObject(claimsSet, kmsSigner);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -4,8 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -30,7 +28,6 @@ import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.DcsPassportCheckService;
 
 import java.time.Instant;
-import java.util.Map;
 
 import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
@@ -141,7 +138,6 @@ public class IssueCredentialHandler
 
     private SignedJWT generateAndSignVerifiableCredentialJwt(
             VerifiableCredential verifiableCredential, String subject) throws JOSEException {
-        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
         Instant now = Instant.now();
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -157,7 +153,7 @@ public class IssueCredentialHandler
                                 new String[] {
                                     VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
                                 })
-                        .claim(VC_CLAIM, mapper.convertValue(verifiableCredential, Map.class))
+                        .claim(VC_CLAIM, verifiableCredential)
                         .build();
 
         return JwtHelper.createSignedJwtFromObject(claimsSet, kmsSigner);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -156,6 +156,6 @@ public class IssueCredentialHandler
                         .claim(VC_CLAIM, verifiableCredential)
                         .build();
 
-        return JwtHelper.createSignedJwtFromObject(claimsSet, kmsSigner);
+        return JwtHelper.createSignedJwtFromClaimSet(claimsSet, kmsSigner);
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -147,6 +147,7 @@ class IssueCredentialHandlerTest {
                 .thenReturn(TEST_RESOURCE_ID);
         when(mockDcsPassportCheckService.getDcsPassportCheck(anyString()))
                 .thenReturn(dcsCredential);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn("test-issuer");
 
         APIGatewayProxyResponseEvent response =
                 issueCredentialHandler.handleRequest(event, mockContext);
@@ -155,14 +156,13 @@ class IssueCredentialHandlerTest {
         JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(7, claimsSet.get("claims").size());
+        assertEquals(7, claimsSet.size());
 
-        JsonNode claims = claimsSet.get("claims");
-        JsonNode vcNode = claims.get("vc");
+        JsonNode vcNode = claimsSet.get("vc");
         VerifiableCredential verifiableCredential =
                 objectMapper.convertValue(vcNode, VerifiableCredential.class);
 
-        assertEquals(SUBJECT, claims.get("sub").asText());
+        assertEquals(SUBJECT, claimsSet.get("sub").asText());
 
         List<NameParts> nameParts =
                 verifiableCredential.getCredentialSubject().getName().getNameParts();
@@ -197,7 +197,7 @@ class IssueCredentialHandlerTest {
                 dcsCredential.getAttributes().getDateOfBirth().toString(),
                 verifiableCredential.getCredentialSubject().getBirthDate().getValue());
         assertEquals(
-                dcsCredential.getAttributes().getExpiryDate(),
+                dcsCredential.getAttributes().getExpiryDate().toString(),
                 verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
                 dcsCredential.getAttributes().getRequestId(),

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -85,7 +85,8 @@ class IssueCredentialHandlerTest {
     private Map<String, String> responseBody;
 
     private final DcsResponse validDcsResponse =
-            new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
+            new DcsResponse(
+                    UUID.randomUUID().toString(), UUID.randomUUID().toString(), false, true, null);
 
     private final PassportAttributes attributes =
             new PassportAttributes(
@@ -200,10 +201,10 @@ class IssueCredentialHandlerTest {
                 dcsCredential.getAttributes().getExpiryDate().toString(),
                 verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
-                dcsCredential.getAttributes().getRequestId(),
+                dcsCredential.getAttributes().getRequestId().toString(),
                 verifiableCredential.getCredentialSubject().getRequestId());
         assertEquals(
-                dcsCredential.getAttributes().getCorrelationId(),
+                dcsCredential.getAttributes().getCorrelationId().toString(),
                 verifiableCredential.getCredentialSubject().getCorrelationId());
         assertEquals(
                 dcsCredential.getGpg45Score().getStrength(),

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -32,8 +32,8 @@ class VerifiableCredentialTest {
         Evidence evidence = new Evidence(4, 4);
         attributes.setDcsResponse(
                 new DcsResponse(
-                        UUID.randomUUID(),
-                        UUID.randomUUID(),
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
                         true,
                         false,
                         Collections.emptyList()));
@@ -67,10 +67,10 @@ class VerifiableCredentialTest {
                 EXPIRY_DATE.toString(),
                 verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
-                passportCheckDao.getAttributes().getRequestId(),
+                passportCheckDao.getAttributes().getRequestId().toString(),
                 verifiableCredential.getCredentialSubject().getRequestId());
         assertEquals(
-                passportCheckDao.getAttributes().getCorrelationId(),
+                passportCheckDao.getAttributes().getCorrelationId().toString(),
                 verifiableCredential.getCredentialSubject().getCorrelationId());
         assertEquals(
                 passportCheckDao.getAttributes().getDcsResponse(),

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -63,7 +63,9 @@ class VerifiableCredentialTest {
         assertEquals(
                 DATE_OF_BIRTH.toString(),
                 verifiableCredential.getCredentialSubject().getBirthDate().getValue());
-        assertEquals(EXPIRY_DATE, verifiableCredential.getCredentialSubject().getExpiryDate());
+        assertEquals(
+                EXPIRY_DATE.toString(),
+                verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
                 passportCheckDao.getAttributes().getRequestId(),
                 verifiableCredential.getCredentialSubject().getRequestId());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsResponse.java
@@ -6,13 +6,12 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.List;
-import java.util.UUID;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 public class DcsResponse {
-    private UUID correlationId;
-    private UUID requestId;
+    private String correlationId;
+    private String requestId;
     private boolean error;
     private boolean valid;
     private List<String> errorMessage;
@@ -21,8 +20,8 @@ public class DcsResponse {
 
     @JsonCreator
     public DcsResponse(
-            @JsonProperty(value = "correlationId", required = true) UUID correlationId,
-            @JsonProperty(value = "requestId", required = true) UUID requestId,
+            @JsonProperty(value = "correlationId", required = true) String correlationId,
+            @JsonProperty(value = "requestId", required = true) String requestId,
             @JsonProperty(value = "error") boolean error,
             @JsonProperty(value = "valid") boolean valid,
             @JsonProperty(value = "errorMessage") List<String> errorMessage) {
@@ -33,19 +32,19 @@ public class DcsResponse {
         this.errorMessage = errorMessage;
     }
 
-    public UUID getCorrelationId() {
+    public String getCorrelationId() {
         return correlationId;
     }
 
-    public void setCorrelationId(UUID correlationId) {
+    public void setCorrelationId(String correlationId) {
         this.correlationId = correlationId;
     }
 
-    public UUID getRequestId() {
+    public String getRequestId() {
         return requestId;
     }
 
-    public void setRequestId(UUID requestId) {
+    public void setRequestId(String requestId) {
         this.requestId = requestId;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 
-import java.util.UUID;
-
 public class CredentialSubject {
 
     @JsonProperty private final Name name;
@@ -20,8 +18,8 @@ public class CredentialSubject {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private final String expiryDate;
 
-    @JsonProperty private final UUID requestId;
-    @JsonProperty private final UUID correlationId;
+    @JsonProperty private final String requestId;
+    @JsonProperty private final String correlationId;
     @JsonProperty private final DcsResponse dcsResponse;
 
     @JsonCreator
@@ -30,8 +28,8 @@ public class CredentialSubject {
             @JsonProperty(value = "passportNumber", required = true) String passportNumber,
             @JsonProperty(value = "birthDate", required = true) BirthDate birthDate,
             @JsonProperty(value = "expiryDate", required = true) String expiryDate,
-            @JsonProperty(value = "requestId", required = true) UUID requestId,
-            @JsonProperty(value = "correlationId", required = true) UUID correlationId,
+            @JsonProperty(value = "requestId", required = true) String requestId,
+            @JsonProperty(value = "correlationId", required = true) String correlationId,
             @JsonProperty(value = "dcsResponse", required = true) DcsResponse dcsResponse) {
         this.name = name;
         this.passportNumber = passportNumber;
@@ -58,11 +56,11 @@ public class CredentialSubject {
         return expiryDate;
     }
 
-    public UUID getRequestId() {
+    public String getRequestId() {
         return requestId;
     }
 
-    public UUID getCorrelationId() {
+    public String getCorrelationId() {
         return correlationId;
     }
 
@@ -75,8 +73,8 @@ public class CredentialSubject {
         private String passportNumber;
         private BirthDate birthDate;
         private String expiryDate;
-        private UUID requestId;
-        private UUID correlationId;
+        private String requestId;
+        private String correlationId;
         private DcsResponse dcsResponse;
 
         public Builder setName(Name name) {
@@ -99,12 +97,12 @@ public class CredentialSubject {
             return this;
         }
 
-        public Builder setRequestId(UUID requestId) {
+        public Builder setRequestId(String requestId) {
             this.requestId = requestId;
             return this;
         }
 
-        public Builder setCorrelationId(UUID correlationId) {
+        public Builder setCorrelationId(String correlationId) {
             this.correlationId = correlationId;
             return this;
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
 public class CredentialSubject {
@@ -19,7 +18,7 @@ public class CredentialSubject {
 
     @JsonProperty
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private final LocalDate expiryDate;
+    private final String expiryDate;
 
     @JsonProperty private final UUID requestId;
     @JsonProperty private final UUID correlationId;
@@ -30,7 +29,7 @@ public class CredentialSubject {
             @JsonProperty(value = "name", required = true) Name name,
             @JsonProperty(value = "passportNumber", required = true) String passportNumber,
             @JsonProperty(value = "birthDate", required = true) BirthDate birthDate,
-            @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
+            @JsonProperty(value = "expiryDate", required = true) String expiryDate,
             @JsonProperty(value = "requestId", required = true) UUID requestId,
             @JsonProperty(value = "correlationId", required = true) UUID correlationId,
             @JsonProperty(value = "dcsResponse", required = true) DcsResponse dcsResponse) {
@@ -55,7 +54,7 @@ public class CredentialSubject {
         return birthDate;
     }
 
-    public LocalDate getExpiryDate() {
+    public String getExpiryDate() {
         return expiryDate;
     }
 
@@ -75,7 +74,7 @@ public class CredentialSubject {
         private Name name;
         private String passportNumber;
         private BirthDate birthDate;
-        private LocalDate expiryDate;
+        private String expiryDate;
         private UUID requestId;
         private UUID correlationId;
         private DcsResponse dcsResponse;
@@ -95,7 +94,7 @@ public class CredentialSubject {
             return this;
         }
 
-        public Builder setExpiryDate(LocalDate expiryDate) {
+        public Builder setExpiryDate(String expiryDate) {
             this.expiryDate = expiryDate;
             return this;
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -44,7 +44,7 @@ public class VerifiableCredential {
                         .setBirthDate(
                                 new BirthDate(
                                         passportCheck.getAttributes().getDateOfBirth().toString()))
-                        .setExpiryDate(passportCheck.getAttributes().getExpiryDate())
+                        .setExpiryDate(passportCheck.getAttributes().getExpiryDate().toString())
                         .setRequestId(passportCheck.getAttributes().getRequestId())
                         .setCorrelationId(passportCheck.getAttributes().getCorrelationId())
                         .setDcsResponse(passportCheck.getAttributes().getDcsResponse())

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -45,8 +45,9 @@ public class VerifiableCredential {
                                 new BirthDate(
                                         passportCheck.getAttributes().getDateOfBirth().toString()))
                         .setExpiryDate(passportCheck.getAttributes().getExpiryDate().toString())
-                        .setRequestId(passportCheck.getAttributes().getRequestId())
-                        .setCorrelationId(passportCheck.getAttributes().getCorrelationId())
+                        .setRequestId(passportCheck.getAttributes().getRequestId().toString())
+                        .setCorrelationId(
+                                passportCheck.getAttributes().getCorrelationId().toString())
                         .setDcsResponse(passportCheck.getAttributes().getDcsResponse())
                         .build();
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelper.java
@@ -23,8 +23,8 @@ public class JwtHelper {
 
     private JwtHelper() {}
 
-    public static <T> SignedJWT createSignedJwtFromObject(JWTClaimsSet claimsSet, JWSSigner signer)
-            throws JOSEException {
+    public static <T> SignedJWT createSignedJwtFromClaimSet(
+            JWTClaimsSet claimsSet, JWSSigner signer) throws JOSEException {
         JWSHeader jwsHeader = generateHeader();
         SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(signer);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelper.java
@@ -23,10 +23,9 @@ public class JwtHelper {
 
     private JwtHelper() {}
 
-    public static <T> SignedJWT createSignedJwtFromObject(T claimInput, JWSSigner signer)
+    public static <T> SignedJWT createSignedJwtFromObject(JWTClaimsSet claimsSet, JWSSigner signer)
             throws JOSEException {
         JWSHeader jwsHeader = generateHeader();
-        JWTClaimsSet claimsSet = generateClaims(claimInput);
         SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(signer);
         return signedJWT;

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -67,8 +67,8 @@ class JwtHelperTest {
                                 PASSPORT_NUMBER,
                                 new BirthDate(BIRTH_DATE),
                                 LocalDate.parse(EXPIRY_DATE).toString(),
-                                UUID.randomUUID(),
-                                UUID.randomUUID(),
+                                UUID.randomUUID().toString(),
+                                UUID.randomUUID().toString(),
                                 new DcsResponse()),
                         new Evidence());
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -81,7 +81,7 @@ class JwtHelperTest {
                         .claim("exp", Instant.now().plusSeconds(100000).getEpochSecond())
                         .build();
 
-        SignedJWT signedJWT = JwtHelper.createSignedJwtFromObject(testClaimsSet, ecSigner);
+        SignedJWT signedJWT = JwtHelper.createSignedJwtFromClaimSet(testClaimsSet, ecSigner);
         JWTClaimsSet generatedClaims = signedJWT.getJWTClaimsSet();
 
         assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1))));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyServiceTest.java
@@ -122,7 +122,12 @@ class DcsCryptographyServiceTest {
                 .thenReturn(TestUtils.getDcsSigningCertificate(BASE64_DCS_SIGNING_CERT));
         when(configurationService.getPassportCriPrivateKey()).thenReturn(getEncryptionPrivateKey());
         DcsResponse expectedDcsResponse =
-                new DcsResponse(UUID.randomUUID(), UUID.randomUUID(), false, true, null);
+                new DcsResponse(
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
+                        false,
+                        true,
+                        null);
         String dcsResponse =
                 generateDCSResponse(objectMapper.writeValueAsString(expectedDcsResponse));
         DcsSignedEncryptedResponse dcsResponseItem = new DcsSignedEncryptedResponse(dcsResponse);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fixed our JWTClaimSet generation. We were previously generating the claim twice causing fields to be stored twice at 2 different levels within the VC.

Also updated the storage of some of the VC parameters to work. Now that we aren't using the jackson object mapper it highlighet some issues when trying to store either a "LocalDate" or a "UUID" variable type. All of these variables have been updated to be stored as Strings.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To fix the structure of the Passport VC.
<!-- Describe the reason these changes were made - the "why" -->

