### PR TITLE
PYIC-927: Give issuecredential lambda SQS perms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -40,6 +40,7 @@ Resources:
           VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialKmsSigningKeyId"
           MAX_JWT_TTL: !Sub "/${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl"
           VERIFIABLE_CREDENTIAL_ISSUER_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialIssuer"
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref DCSResponseTable
@@ -51,6 +52,8 @@ Resources:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialIssuer
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
         - Statement:
             - Sid: kmsSigningKeyPermission
               Effect: Allow
@@ -58,6 +61,13 @@ Resources:
                 - 'kms:sign'
               Resource:
                 - !ImportValue PassportCriVcSigningKeyArn
+            - Sid: auditEventQueueKmsEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCriUKPassportAPI:
           Type: Api


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Give issuecredential lambda SQS perms
- Add the SQS queue URL to the lambda as an env var 

### Why did it change

Add the perms required for the issuecredential lambda to write to the
audit event SQS queue.

`SQSSendMessagePolicy` gives the message write permissions. We also need
the KMS permissions as the queue is configured to encrypt messages at
rest and SAM doesn't have a policy template that covers this (obviously
required) use case.

This also adds the SQS queue URL to the lambda as an env var so the lib
actually sending the messages know where to send them.

Whilst not strictly in scope for the core team for slice 2, I've added
it to this lambda first as the KBV teams designated slice 2 message is
`KBV_ADDRESS_CREDENTIAL_ISSUED`. So assuming a matching first message
from the Passport CRI, this lambda is the correct place.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-927](https://govukverify.atlassian.net/browse/PYI-927)
