### PR TITLE
PYIC-862: Send audit event to the sqs queue for when a request has been sent to DCS

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -145,6 +145,7 @@ Resources:
           DCS_TLS_ROOT_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/tlsRootCertificate"
           DCS_TLS_INTERMEDIATE_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/tlsIntermediateCertificate"
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref DCSResponseTable
@@ -154,6 +155,16 @@ Resources:
             TableName: !Ref CRIPassportAuthCodesTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: auditEventQueueKmsEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/lambdas/authorizationcode/build.gradle
+++ b/lambdas/authorizationcode/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
+			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
 			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
+			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
 			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.146",
+			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
 			"com.nimbusds:oauth2-oidc-sdk:9.22.1",
 			"com.fasterxml.jackson.core:jackson-core:2.13.1",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.1",

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
@@ -1,0 +1,29 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class AuditEvent {
+    @JsonProperty private int timestamp;
+
+    @JsonProperty("event_name")
+    private AuditEventTypes event;
+
+    @JsonCreator
+    public AuditEvent(
+            @JsonProperty(value = "timestamp", required = true) int timestamp,
+            @JsonProperty(value = "event_name", required = true) AuditEventTypes event) {
+        this.timestamp = timestamp;
+        this.event = event;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public AuditEventTypes getEvent() {
+        return event;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventTypes.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public enum AuditEventTypes {
+    PASSPORT_REQUEST_SENT_TO_DCS,
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventTypes.java
@@ -5,4 +5,5 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 @ExcludeFromGeneratedCoverageReport
 public enum AuditEventTypes {
     PASSPORT_REQUEST_SENT_TO_DCS,
+    PASSPORT_CREDENTIAL_ISSUED
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -21,7 +21,9 @@ public enum ErrorResponse {
     INVALID_REDIRECT_URL(1012, "Provided redirect URL is not in those configured for client"),
     UNKNOWN_CLIENT_ID(1013, "Unknown client id provided in request params"),
     INVALID_REQUEST_PARAM(1014, "Invalid request param"),
-    SHARED_CLAIM_IS_MISSING(1015, "shared_claim missing from shared attribute JWT");
+    SHARED_CLAIM_IS_MISSING(1015, "shared_claim missing from shared attribute JWT"),
+    FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE(
+            1016, "Failed to send message to aws SQS audit event queue");
 
     private final int code;
     private final String message;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/SqsException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/SqsException.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.cri.passport.library.exceptions;
+
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class SqsException extends Exception {
+    public SqsException(Throwable e) {
+        super(e);
+    }
+
+    public SqsException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
@@ -1,0 +1,46 @@
+package uk.gov.di.ipv.cri.passport.library.service;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
+
+import java.time.Instant;
+
+public class AuditService {
+    private final AmazonSQS sqs;
+    private final String queueUrl;
+
+    public AuditService(AmazonSQS sqs, ConfigurationService configurationService) {
+        this.sqs = sqs;
+        queueUrl = configurationService.getSqsAuditEventQueueUrl();
+    }
+
+    public static AmazonSQS getDefaultSqsClient() {
+        return AmazonSQSClientBuilder.defaultClient();
+    }
+
+    public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {
+        try {
+            SendMessageRequest sendMessageRequest =
+                    new SendMessageRequest()
+                            .withQueueUrl(queueUrl)
+                            .withMessageBody(generateMessageBody(eventType));
+
+            sqs.sendMessage(sendMessageRequest);
+        } catch (JsonProcessingException e) {
+            throw new SqsException(e);
+        }
+    }
+
+    private String generateMessageBody(AuditEventTypes eventType) throws JsonProcessingException {
+        AuditEvent auditEvent = new AuditEvent((int) Instant.now().getEpochSecond(), eventType);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(auditEvent);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -78,6 +78,10 @@ public class ConfigurationService {
         return System.getenv("CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME");
     }
 
+    public String getSqsAuditEventQueueUrl() {
+        return System.getenv("SQS_AUDIT_EVENT_QUEUE_URL");
+    }
+
     private String getParameterFromStoreUsingEnv(String environmentVariable) {
         return ssmProvider.get(System.getenv(environmentVariable));
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
@@ -1,0 +1,54 @@
+package uk.gov.di.ipv.cri.passport.library.service;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuditServiceTest {
+    @Mock AmazonSQS mockSqs;
+    @Mock ConfigurationService mockConfigurationService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private AuditService auditService;
+
+    @BeforeEach
+    void setup() {
+        when(mockConfigurationService.getSqsAuditEventQueueUrl())
+                .thenReturn("https://example-queue-url");
+
+        auditService = new AuditService(mockSqs, mockConfigurationService);
+    }
+
+    @Test
+    void shouldSendMessageToSqsQueue() throws JsonProcessingException, SqsException {
+        auditService.sendAuditEvent(AuditEventTypes.PASSPORT_REQUEST_SENT_TO_DCS);
+
+        ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
+                ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(mockSqs).sendMessage(sqsSendMessageRequestCaptor.capture());
+
+        assertEquals(
+                "https://example-queue-url", sqsSendMessageRequestCaptor.getValue().getQueueUrl());
+
+        AuditEvent messageBody =
+                objectMapper.readValue(
+                        sqsSendMessageRequestCaptor.getValue().getMessageBody(), AuditEvent.class);
+        assertEquals(AuditEventTypes.PASSPORT_REQUEST_SENT_TO_DCS, messageBody.getEvent());
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add common Audit service that writes audit events onto the passport SQS queue. This will write an event onto the queue to track when we have sent a request to DCS.

This is the same implementation as on ipv-core and will write the messages onto the queue in JSON format.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-862](https://govukverify.atlassian.net/browse/PYI-862)

