### PR TITLE
PYIC-946: Validate JAR request from ipv-core

### DIFF
--- a/lambdas/sharedattributes/build.gradle
+++ b/lambdas/sharedattributes/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
 			"org.mockito:mockito-core:4.1.0",
+			"org.mockito:mockito-inline:2.13.0",
 			project(":lib").sourceSets.test.output
 }
 

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandler.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
-import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
@@ -74,7 +74,7 @@ public class SharedAttributesHandler
             }
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(OK, sharedClaims);
-        } catch (SharedAttributesValidationException e) {
+        } catch (JarValidationException e) {
             LOGGER.error("JAR validation failed: ", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandler.java
@@ -4,8 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
@@ -13,10 +11,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
 import uk.gov.di.ipv.cri.passport.library.helpers.ApiGatewayResponseGenerator;
-import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
 
 import java.text.ParseException;
 import java.util.Map;
@@ -25,20 +24,25 @@ public class SharedAttributesHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     public static final String SHARED_CLAIMS = "shared_claims";
+
     private final ConfigurationService configurationService;
+    private final JarValidator jarValidator;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SharedAttributesHandler.class);
     private static final Integer OK = 200;
     private static final Integer BAD_REQUEST = 400;
     private static final String CLIENT_ID = "client_id";
 
-    public SharedAttributesHandler(ConfigurationService configurationService) {
+    public SharedAttributesHandler(
+            ConfigurationService configurationService, JarValidator jarValidator) {
         this.configurationService = configurationService;
+        this.jarValidator = jarValidator;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public SharedAttributesHandler() {
         this.configurationService = new ConfigurationService();
+        this.jarValidator = new JarValidator(configurationService);
     }
 
     @Override
@@ -58,17 +62,11 @@ public class SharedAttributesHandler
         }
 
         try {
-            SignedJWT signedJWT = SignedJWT.parse(input.getBody());
+            SignedJWT signedJWT = jarValidator.decryptJWE(input.getBody());
 
-            if (isInvalidSignature(signedJWT, clientId)) {
-                LOGGER.error("JWT signature is invalid");
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        BAD_REQUEST, ErrorResponse.JWT_SIGNATURE_IS_INVALID);
-            }
+            JWTClaimsSet claimsSet = jarValidator.validateRequestJwt(signedJWT, clientId);
 
-            JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             Map<String, Object> sharedClaims = claimsSet.getJSONObjectClaim(SHARED_CLAIMS);
-
             if (sharedClaims == null) {
                 LOGGER.error("shared_claim not found in JWT");
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
@@ -76,26 +74,14 @@ public class SharedAttributesHandler
             }
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(OK, sharedClaims);
+        } catch (SharedAttributesValidationException e) {
+            LOGGER.error("JAR validation failed: ", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());
         } catch (ParseException e) {
-            LOGGER.error("Failed to parse", e);
+            LOGGER.error("Failed to parse claim set when attempting to retrieve shared_claim");
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE);
-        } catch (JOSEException e) {
-            LOGGER.error("Failed to verify the signature of the JWT", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    BAD_REQUEST, ErrorResponse.FAILED_TO_VERIFY_SIGNATURE);
         }
-    }
-
-    private boolean isInvalidSignature(SignedJWT signedJWT, String clientId)
-            throws JOSEException, ParseException {
-        SignedJWT concatSignatureJwt;
-        if (JwtHelper.signatureIsDerFormat(signedJWT)) {
-            concatSignatureJwt = JwtHelper.transcodeSignature(signedJWT);
-        } else {
-            concatSignatureJwt = signedJWT;
-        }
-        return !concatSignatureJwt.verify(
-                new ECDSAVerifier(configurationService.getClientSigningPublicJwk(clientId)));
     }
 }

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
@@ -82,7 +82,6 @@ class SharedAttributesHandlerTest {
 
     @Test
     void shouldReturn200WhenGivenValidJWT() throws Exception {
-        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
@@ -98,7 +97,6 @@ class SharedAttributesHandlerTest {
 
     @Test
     void shouldReturnClaimsAsJsonFromJWT() throws Exception {
-        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
@@ -139,7 +137,6 @@ class SharedAttributesHandlerTest {
     @Test
     void shouldReturn400IfFailedToParseJWTClaimSet()
             throws JsonProcessingException, JarValidationException, ParseException {
-        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
 
         JWTClaimsSet myMock = mock(JWTClaimsSet.class);
         when(myMock.getJSONObjectClaim(anyString()))
@@ -150,7 +147,7 @@ class SharedAttributesHandlerTest {
         Map<String, String> map = new HashMap<>();
         map.put("client_id", "TEST");
         event.setHeaders(map);
-        event.setBody("Not a valid JWT");
+        event.setBody(signedJWT.serialize());
 
         var response = underTest.handleRequest(event, context);
 
@@ -177,7 +174,6 @@ class SharedAttributesHandlerTest {
 
     @Test
     void shouldReturn302WhenValidationFails() throws Exception {
-        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString()))
                 .thenThrow(new JarValidationException(OAuth2Error.INVALID_REQUEST_OBJECT));
 
@@ -205,7 +201,6 @@ class SharedAttributesHandlerTest {
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder().claim("NO_SHARED_CLAIMS_CLAIM_PRESENT", "Nope").build();
 
-        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString())).thenReturn(claimsSet);
 
         SignedJWT signedJwtWithoutClaim =

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
-import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
 
@@ -138,7 +138,7 @@ class SharedAttributesHandlerTest {
 
     @Test
     void shouldReturn400IfFailedToParseJWTClaimSet()
-            throws JsonProcessingException, SharedAttributesValidationException, ParseException {
+            throws JsonProcessingException, JarValidationException, ParseException {
         when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
 
         JWTClaimsSet myMock = mock(JWTClaimsSet.class);
@@ -179,9 +179,7 @@ class SharedAttributesHandlerTest {
     void shouldReturn302WhenValidationFails() throws Exception {
         when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString()))
-                .thenThrow(
-                        new SharedAttributesValidationException(
-                                OAuth2Error.INVALID_REQUEST_OBJECT));
+                .thenThrow(new JarValidationException(OAuth2Error.INVALID_REQUEST_OBJECT));
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> map = new HashMap<>();

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/cri/passport/sharedattributes/SharedAttributesHandlerTest.java
@@ -5,20 +5,25 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -34,9 +39,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
-import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PUBLIC_JWK_1;
 import static uk.gov.di.ipv.cri.passport.sharedattributes.SharedAttributesHandler.SHARED_CLAIMS;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +52,10 @@ class SharedAttributesHandlerTest {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Mock private ConfigurationService configurationService;
+
+    @Mock private JarValidator jarValidator;
+
+    @Mock private JWTClaimsSet mockJwtClaimSet;
 
     private SharedAttributesHandler underTest;
 
@@ -66,13 +77,14 @@ class SharedAttributesHandlerTest {
         signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
         signedJWT.sign(new ECDSASigner(getPrivateKey()));
 
-        underTest = new SharedAttributesHandler(configurationService);
+        underTest = new SharedAttributesHandler(configurationService, jarValidator);
     }
 
     @Test
     void shouldReturn200WhenGivenValidJWT() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
+        when(jarValidator.validateRequestJwt(any(), anyString()))
+                .thenReturn(signedJWT.getJWTClaimsSet());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> map = new HashMap<>();
@@ -86,8 +98,10 @@ class SharedAttributesHandlerTest {
 
     @Test
     void shouldReturnClaimsAsJsonFromJWT() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
+        when(jarValidator.validateRequestJwt(any(), anyString()))
+                .thenReturn(signedJWT.getJWTClaimsSet());
+
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> map = new HashMap<>();
         map.put("client_id", "TEST");
@@ -123,7 +137,15 @@ class SharedAttributesHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfFailedToParseJWT() throws JsonProcessingException {
+    void shouldReturn400IfFailedToParseJWTClaimSet()
+            throws JsonProcessingException, SharedAttributesValidationException, ParseException {
+        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
+
+        JWTClaimsSet myMock = mock(JWTClaimsSet.class);
+        when(myMock.getJSONObjectClaim(anyString()))
+                .thenThrow(new ParseException("Failed to parse jwt claim set", 0));
+        when(jarValidator.validateRequestJwt(any(), anyString())).thenReturn(myMock);
+
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> map = new HashMap<>();
         map.put("client_id", "TEST");
@@ -154,9 +176,12 @@ class SharedAttributesHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenSignatureVerificationFails() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+    void shouldReturn302WhenValidationFails() throws Exception {
+        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
+        when(jarValidator.validateRequestJwt(any(), anyString()))
+                .thenThrow(
+                        new SharedAttributesValidationException(
+                                OAuth2Error.INVALID_REQUEST_OBJECT));
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> map = new HashMap<>();
@@ -168,69 +193,22 @@ class SharedAttributesHandlerTest {
 
         var response = underTest.handleRequest(event, context);
 
-        Map<String, Object> error =
-                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.JWT_SIGNATURE_IS_INVALID.getCode(), error.get("code"));
-        assertEquals(ErrorResponse.JWT_SIGNATURE_IS_INVALID.getMessage(), error.get("message"));
+        ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
+
+        assertEquals(302, response.getStatusCode());
+        assertEquals(OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), errorResponse.getCode());
+        assertEquals(
+                OAuth2Error.INVALID_REQUEST_OBJECT.getDescription(),
+                errorResponse.getDescription());
     }
 
     @Test
-    void shouldReturn400WhenJwkParsingFails() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenThrow(new ParseException("Failed to parse JWK", 0));
-
-        var event = new APIGatewayProxyRequestEvent();
-        Map<String, String> map = new HashMap<>();
-        map.put("client_id", "TEST");
-        event.setHeaders(map);
-        event.setBody(signedJWT.serialize());
-
-        var response = underTest.handleRequest(event, context);
-
-        Map<String, Object> error =
-                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_PARSE.getCode(), error.get("code"));
-        assertEquals(ErrorResponse.FAILED_TO_PARSE.getMessage(), error.get("message"));
-    }
-
-    @Test
-    void shouldReturn400WhenClaimsClaimMissing() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
-
+    void shouldReturn400WhenSharedClaimsClaimMissing() throws Exception {
         JWTClaimsSet claimsSet =
-                new JWTClaimsSet.Builder().claim("NO_CLAIMS_CLAIM_PRESENT", "Nope").build();
+                new JWTClaimsSet.Builder().claim("NO_SHARED_CLAIMS_CLAIM_PRESENT", "Nope").build();
 
-        SignedJWT signedJwtWithoutClaim =
-                new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
-        signedJwtWithoutClaim.sign(new ECDSASigner(getPrivateKey()));
-
-        var event = new APIGatewayProxyRequestEvent();
-        Map<String, String> map = new HashMap<>();
-        map.put("client_id", "TEST");
-        event.setHeaders(map);
-        event.setBody(signedJwtWithoutClaim.serialize());
-
-        var response = underTest.handleRequest(event, context);
-
-        Map<String, Object> error =
-                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.SHARED_CLAIM_IS_MISSING.getCode(), error.get("code"));
-        assertEquals(ErrorResponse.SHARED_CLAIM_IS_MISSING.getMessage(), error.get("message"));
-    }
-
-    @Test
-    void shouldReturn400WhenVcHttpApiClaimMissingFromClaimsClaim() throws Exception {
-        when(configurationService.getClientSigningPublicJwk("TEST"))
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
-
-        JWTClaimsSet claimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim("claims", Map.of("not_vc_http_api_claim", "nope"))
-                        .build();
+        when(jarValidator.decryptJWE(anyString())).thenReturn(signedJWT);
+        when(jarValidator.validateRequestJwt(any(), anyString())).thenReturn(claimsSet);
 
         SignedJWT signedJwtWithoutClaim =
                 new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
@@ -257,5 +235,13 @@ class SharedAttributesHandlerTest {
                         .generatePrivate(
                                 new PKCS8EncodedKeySpec(
                                         Base64.getDecoder().decode(EC_PRIVATE_KEY_1)));
+    }
+
+    private ErrorObject createErrorObjectFromResponse(String responseBody)
+            throws com.nimbusds.oauth2.sdk.ParseException {
+        HTTPResponse httpErrorResponse = new HTTPResponse(400);
+        httpErrorResponse.setContentType(ContentType.APPLICATION_JSON.getType());
+        httpErrorResponse.setContent(responseBody);
+        return ErrorObject.parse(httpErrorResponse);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/JarValidationException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/JarValidationException.java
@@ -4,10 +4,10 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
-public class SharedAttributesValidationException extends Exception {
+public class JarValidationException extends Exception {
     private final ErrorObject errorObject;
 
-    public SharedAttributesValidationException(ErrorObject errorObject) {
+    public JarValidationException(ErrorObject errorObject) {
         this.errorObject = errorObject;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/SharedAttributesValidationException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/SharedAttributesValidationException.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.cri.passport.library.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class SharedAttributesValidationException extends Exception {
+    private final ErrorObject errorObject;
+
+    public SharedAttributesValidationException(ErrorObject errorObject) {
+        this.errorObject = errorObject;
+    }
+
+    public ErrorObject getErrorObject() {
+        return errorObject;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -224,13 +224,6 @@ public class ConfigurationService {
                         System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
     }
 
-    public String getClientSigningAlgorithm(String clientId) throws UnknownClientException {
-        return ssmProvider.get(
-                String.format(
-                        "%s/%s/jwtAuthentication/signingAlgorithm",
-                        System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
-    }
-
     public String getAudienceForClients() {
         return getParameterFromStoreUsingEnv("PASSPORT_CRI_CLIENT_AUDIENCE");
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -34,17 +34,10 @@ public class JarValidator {
         this.configurationService = configurationService;
     }
 
-    public SignedJWT decryptJWE(String jweString) throws JarValidationException {
-        try {
-            JWEObject jweObject = JWEObject.parse(jweString);
+    public SignedJWT decryptJWE(JWEObject jweObject) {
+        // Decrypt functionality to go here...
 
-            // Decrypt functionality to go here...
-
-            return jweObject.getPayload().toSignedJWT();
-        } catch (ParseException e) {
-            LOGGER.error("Failed to parse request body into a JWE");
-            throw new JarValidationException(OAuth2Error.INVALID_REQUEST_OBJECT);
-        }
+        return jweObject.getPayload().toSignedJWT();
     }
 
     public JWTClaimsSet validateRequestJwt(SignedJWT signedJWT, String clientId)

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -140,7 +140,7 @@ public class JarValidator {
 
             return signedJWT.getJWTClaimsSet();
         } catch (BadJWTException | ParseException e) {
-            LOGGER.error("Claim set validation failed: {}", e.getMessage());
+            LOGGER.error("Claim set validation failed");
             throw new SharedAttributesValidationException(
                     OAuth2Error.INVALID_GRANT.setDescription(e.getMessage()));
         }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -1,0 +1,187 @@
+package uk.gov.di.ipv.cri.passport.library.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
+import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+
+import java.net.URI;
+import java.text.ParseException;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+public class JarValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JarValidator.class);
+    private static final String REDIRECT_URI_CLAIM = "redirect_uri";
+
+    private final ConfigurationService configurationService;
+
+    public JarValidator(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public SignedJWT decryptJWE(String jweString) throws SharedAttributesValidationException {
+        try {
+            JWEObject jweObject = JWEObject.parse(jweString);
+
+            // Decrypt functionality to go here...
+
+            return jweObject.getPayload().toSignedJWT();
+        } catch (ParseException e) {
+            LOGGER.error("Failed to parse request body into a JWE");
+            throw new SharedAttributesValidationException(OAuth2Error.INVALID_REQUEST_OBJECT);
+        }
+    }
+
+    public JWTClaimsSet validateRequestJwt(SignedJWT signedJWT, String clientId)
+            throws SharedAttributesValidationException {
+        validateClientId(clientId);
+        validateJWTHeader(signedJWT, clientId);
+        validateSignature(signedJWT, clientId);
+        JWTClaimsSet claimsSet = validateClaimSet(signedJWT, clientId);
+        validateRedirectUri(claimsSet, clientId);
+
+        return claimsSet;
+    }
+
+    private void validateClientId(String clientId) throws SharedAttributesValidationException {
+        try {
+            configurationService.getClientAuthenticationMethod(clientId);
+        } catch (ParameterNotFoundException e) {
+            LOGGER.error("Unknown client id provided {}", clientId);
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_CLIENT.setDescription("Unknown client id was provided"));
+        }
+    }
+
+    private void validateJWTHeader(SignedJWT signedJWT, String clientId)
+            throws SharedAttributesValidationException {
+        JWSAlgorithm configuredAlgorithm =
+                JWSAlgorithm.parse(configurationService.getClientSigningAlgorithm(clientId));
+        JWSAlgorithm jwtAlgorithm = signedJWT.getHeader().getAlgorithm();
+        if (jwtAlgorithm != configuredAlgorithm) {
+            LOGGER.error(
+                    "jwt signing algorithm {} does not match signing algorithm configured for client: {}",
+                    jwtAlgorithm,
+                    configuredAlgorithm);
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                            "Signing algorithm used does not match required algorithm configured for client"));
+        }
+    }
+
+    private void validateSignature(SignedJWT signedJWT, String clientId)
+            throws SharedAttributesValidationException {
+        try {
+            SignedJWT concatSignatureJwt;
+            if (JwtHelper.signatureIsDerFormat(signedJWT)) {
+                concatSignatureJwt = JwtHelper.transcodeSignature(signedJWT);
+            } else {
+                concatSignatureJwt = signedJWT;
+            }
+            boolean valid =
+                    concatSignatureJwt.verify(
+                            new ECDSAVerifier(
+                                    configurationService.getClientSigningPublicJwk(clientId)));
+
+            if (!valid) {
+                LOGGER.error("JWT signature validation failed");
+                throw new SharedAttributesValidationException(
+                        OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                                "JWT signature validation failed"));
+            }
+        } catch (JOSEException | ParseException e) {
+            LOGGER.error("Failed to parse JWT when attempting signature validation");
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                            "Failed to parse JWT when attempting signature validation"));
+        }
+    }
+
+    private JWTClaimsSet validateClaimSet(SignedJWT signedJWT, String clientId)
+            throws SharedAttributesValidationException {
+
+        String criAudience = configurationService.getAudienceForClients();
+        String clientIssuer = configurationService.getClientIssuer(clientId);
+
+        DefaultJWTClaimsVerifier<?> verifier =
+                new DefaultJWTClaimsVerifier<>(
+                        criAudience,
+                        new JWTClaimsSet.Builder()
+                                .issuer(clientIssuer)
+                                .claim("response_type", "code")
+                                .build(),
+                        new HashSet<>(
+                                Arrays.asList(
+                                        JWTClaimNames.EXPIRATION_TIME,
+                                        JWTClaimNames.NOT_BEFORE,
+                                        JWTClaimNames.ISSUED_AT,
+                                        JWTClaimNames.SUBJECT)));
+
+        try {
+            verifier.verify(signedJWT.getJWTClaimsSet(), null);
+
+            validateDateClaims(signedJWT.getJWTClaimsSet());
+
+            return signedJWT.getJWTClaimsSet();
+        } catch (BadJWTException | ParseException e) {
+            LOGGER.error("Claim set validation failed: {}", e.getMessage());
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_GRANT.setDescription(e.getMessage()));
+        }
+    }
+
+    private void validateDateClaims(JWTClaimsSet claimsSet)
+            throws SharedAttributesValidationException {
+        Date expirationTime = claimsSet.getExpirationTime();
+        String maxAllowedTtl = configurationService.getMaxClientAuthTokenTtl();
+
+        OffsetDateTime offsetDateTime =
+                OffsetDateTime.now().plusSeconds(Long.parseLong(maxAllowedTtl));
+        if (expirationTime.getTime() / 1000L > offsetDateTime.toEpochSecond()) {
+            LOGGER.error("Client JWT expiry date is too far in the future");
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_GRANT.setDescription(
+                            "The client JWT expiry date has surpassed the maximum allowed ttl value"));
+        }
+    }
+
+    private void validateRedirectUri(JWTClaimsSet claimsSet, String clientId)
+            throws SharedAttributesValidationException {
+        try {
+            URI redirectUri = claimsSet.getURIClaim(REDIRECT_URI_CLAIM);
+            List<String> allowedRedirectUris = configurationService.getClientRedirectUrls(clientId);
+
+            if (!allowedRedirectUris.contains(redirectUri.toString())) {
+                LOGGER.error(
+                        "Invalid redirect_uri claim ({}) provided for client: {}",
+                        redirectUri,
+                        clientId);
+                throw new SharedAttributesValidationException(
+                        OAuth2Error.INVALID_GRANT.setDescription(
+                                "Invalid redirct_uri claim provided for configured client"));
+            }
+        } catch (ParseException e) {
+            LOGGER.error(
+                    "Failed to parse JWT claim set in order to access to the redirect_uri claim");
+            throw new SharedAttributesValidationException(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                            "Failed to parse JWT claim set in order to access redirect_uri claim"));
+        }
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -66,18 +66,6 @@ class JarValidatorTest {
     }
 
     @Test
-    void shouldThrowExceptionIfDecrptionParsingFails() {
-        String invalidJWE = "invalid-jwe-value";
-        try {
-            jarValidator.decryptJWE(invalidJWE);
-            fail("Should throw a SharedAttributesValidationException");
-        } catch (JarValidationException e) {
-            assertEquals(
-                    OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), e.getErrorObject().getCode());
-        }
-    }
-
-    @Test
     void shouldPassValidationChecksOnValidJARRequest()
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     ParseException {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -1,0 +1,686 @@
+package uk.gov.di.ipv.cri.passport.library.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SharedAttributesValidationException;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
+import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PUBLIC_JWK_1;
+import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PUBLIC_JWK_2;
+import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.RSA_PUBLIC_KEY;
+
+@ExtendWith(MockitoExtension.class)
+class JarValidatorTest {
+
+    @Mock private ConfigurationService configurationService;
+
+    private JarValidator jarValidator;
+
+    private final String audienceClaim = "test-audience";
+    private final String issuerClaim = "test-issuer";
+    private final String subjectClaim = "test-subject";
+    private final String responseTypeClaim = "code";
+    private final String clientIdClaim = "test-client-id";
+    private final String redirectUriClaim = "https://example.com";
+    private final String stateClaim = "af0ifjsldkj";
+
+    @BeforeEach
+    void setUp() {
+        jarValidator = new JarValidator(configurationService);
+    }
+
+    @Test
+    void shouldThrowExceptionIfDecrptionParsingFails() {
+        String invalidJWE = "invalid-jwe-value";
+        try {
+            jarValidator.decryptJWE(invalidJWE);
+            fail("Should throw a SharedAttributesValidationException");
+        } catch (SharedAttributesValidationException e) {
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), e.getErrorObject().getCode());
+        }
+    }
+
+    @Test
+    void shouldPassValidationChecksOnValidJARRequest()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+        when(configurationService.getMaxClientAuthTokenTtl()).thenReturn("1500");
+        when(configurationService.getClientRedirectUrls(anyString()))
+                .thenReturn(Collections.singletonList(redirectUriClaim));
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+        } catch (SharedAttributesValidationException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidClientId()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientAuthenticationMethod(anyString()))
+                .thenThrow(ParameterNotFoundException.builder().build());
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_CLIENT.getHTTPStatusCode(),
+                    errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorObject.getCode());
+            assertEquals("Unknown client id was provided", errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnValidJWTalgHeader()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.RS512.toString());
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getHTTPStatusCode(),
+                    errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "Signing algorithm used does not match required algorithm configured for client",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidJWTSignature()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_2));
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getHTTPStatusCode(),
+                    errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), errorObject.getCode());
+            assertEquals("JWT signature validation failed", errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidPublicJwk()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenThrow(new ParseException("test-error", 0));
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getHTTPStatusCode(),
+                    errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "Failed to parse JWT when attempting signature validation",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnMissingRequiredClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        ECDSASigner signer = new ECDSASigner(getPrivateKey());
+
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder().claim(JWTClaimNames.AUDIENCE, audienceClaim).build();
+
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        claimsSet);
+        signedJWT.sign(signer);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "JWT missing required claims: [exp, iat, iss, nbf, response_type, sub]",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidAudienceClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        "invalid-audience",
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals("JWT audience rejected: [invalid-audience]", errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidIssuerClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        "invalid-issuer",
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "JWT iss claim has value invalid-issuer, must be test-issuer",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidResponseTypeClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        "invalid-response-type",
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "JWT response_type claim has value invalid-response-type, must be code",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnExpiredJWT()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesInPast(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals("Expired JWT", errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnFutureNbfClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals("JWT before use time", errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnExpiryClaimToFarInFuture()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+        when(configurationService.getMaxClientAuthTokenTtl()).thenReturn("1500");
+
+        Map<String, Object> invalidAudienceClaims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        OffsetDateTime.now().plusYears(100).toEpochSecond(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        redirectUriClaim,
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(invalidAudienceClaims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "The client JWT expiry date has surpassed the maximum allowed ttl value",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnInvalidRedirectUriClaim()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+        when(configurationService.getMaxClientAuthTokenTtl()).thenReturn("1500");
+        when(configurationService.getClientRedirectUrls(anyString()))
+                .thenReturn(Collections.singletonList("test-redirect-uri"));
+
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "Invalid redirct_uri claim provided for configured client",
+                    errorObject.getDescription());
+        }
+    }
+
+    @Test
+    void shouldFailValidationChecksOnParseFailureOfRedirectUri()
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
+                    ParseException {
+        when(configurationService.getClientSigningAlgorithm(anyString()))
+                .thenReturn(JWSAlgorithm.ES256.toString());
+        when(configurationService.getClientSigningPublicJwk(anyString()))
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_1));
+        when(configurationService.getAudienceForClients()).thenReturn(audienceClaim);
+        when(configurationService.getClientIssuer(anyString())).thenReturn(issuerClaim);
+        when(configurationService.getMaxClientAuthTokenTtl()).thenReturn("1500");
+
+        Map<String, Object> claims =
+                Map.of(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        fifteenMinutesFromNow(),
+                        JWTClaimNames.ISSUED_AT,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.NOT_BEFORE,
+                        OffsetDateTime.now().toEpochSecond(),
+                        JWTClaimNames.AUDIENCE,
+                        audienceClaim,
+                        JWTClaimNames.ISSUER,
+                        issuerClaim,
+                        JWTClaimNames.SUBJECT,
+                        subjectClaim,
+                        "response_type",
+                        responseTypeClaim,
+                        "client_id",
+                        clientIdClaim,
+                        "redirect_uri",
+                        "({[]})./sd-234345////invalid-redirect-uri",
+                        "state",
+                        stateClaim);
+
+        SignedJWT signedJWT = generateJWT(claims);
+
+        try {
+            jarValidator.validateRequestJwt(signedJWT, clientIdClaim);
+            fail();
+        } catch (SharedAttributesValidationException e) {
+            ErrorObject errorObject = e.getErrorObject();
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getHTTPStatusCode(),
+                    errorObject.getHTTPStatusCode());
+            assertEquals(OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), errorObject.getCode());
+            assertEquals(
+                    "Failed to parse JWT claim set in order to access redirect_uri claim",
+                    errorObject.getDescription());
+        }
+    }
+
+    private SignedJWT generateJWT(Map<String, Object> claimsSetValues)
+            throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
+        ECDSASigner signer = new ECDSASigner(getPrivateKey());
+
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        generateClaimsSet(claimsSetValues));
+        signedJWT.sign(signer);
+
+        return signedJWT;
+    }
+
+    private Map<String, Object> getValidClaimsSetValues() {
+        return Map.of(
+                JWTClaimNames.EXPIRATION_TIME,
+                fifteenMinutesFromNow(),
+                JWTClaimNames.ISSUED_AT,
+                OffsetDateTime.now().toEpochSecond(),
+                JWTClaimNames.NOT_BEFORE,
+                OffsetDateTime.now().toEpochSecond(),
+                JWTClaimNames.AUDIENCE,
+                audienceClaim,
+                JWTClaimNames.ISSUER,
+                issuerClaim,
+                JWTClaimNames.SUBJECT,
+                subjectClaim,
+                "response_type",
+                responseTypeClaim,
+                "client_id",
+                clientIdClaim,
+                "redirect_uri",
+                redirectUriClaim,
+                "state",
+                stateClaim);
+    }
+
+    private JWTClaimsSet generateClaimsSet(Map<String, Object> claimsSetValues) {
+        return new JWTClaimsSet.Builder()
+                .claim(
+                        JWTClaimNames.EXPIRATION_TIME,
+                        claimsSetValues.get(JWTClaimNames.EXPIRATION_TIME))
+                .claim(JWTClaimNames.ISSUED_AT, claimsSetValues.get(JWTClaimNames.ISSUED_AT))
+                .claim(JWTClaimNames.NOT_BEFORE, claimsSetValues.get(JWTClaimNames.NOT_BEFORE))
+                .claim(JWTClaimNames.AUDIENCE, claimsSetValues.get(JWTClaimNames.AUDIENCE))
+                .claim(JWTClaimNames.ISSUER, claimsSetValues.get(JWTClaimNames.ISSUER))
+                .claim(JWTClaimNames.SUBJECT, claimsSetValues.get(JWTClaimNames.SUBJECT))
+                .claim("response_type", claimsSetValues.get("response_type"))
+                .claim("client_id", claimsSetValues.get("client_id"))
+                .claim("redirect_uri", claimsSetValues.get("redirect_uri"))
+                .claim("state", claimsSetValues.get("state"))
+                .build();
+    }
+
+    private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {
+        return (ECPrivateKey)
+                KeyFactory.getInstance("EC")
+                        .generatePrivate(
+                                new PKCS8EncodedKeySpec(
+                                        Base64.getDecoder().decode(EC_PRIVATE_KEY_1)));
+    }
+
+    private RSAPublicKey getPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return (RSAPublicKey)
+                KeyFactory.getInstance("RSA")
+                        .generatePublic(
+                                new X509EncodedKeySpec(Base64.getDecoder().decode(RSA_PUBLIC_KEY)));
+    }
+
+    private static long fifteenMinutesFromNow() {
+        return OffsetDateTime.now().plusSeconds(15 * 60).toEpochSecond();
+    }
+
+    private static long fifteenMinutesInPast() {
+        return OffsetDateTime.now().minusSeconds(15 * 60).toEpochSecond();
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Crated a new validator class to validate the new JAR request from ipv-core. The validator will check the following:

- Validates the client_id is one we have configured within SSM
- Validates the JWT header matches the signing algorithm we have configured for the client
- Validates the JWT signature
- Validates the various JWT claims i.e, correct values for aud, iss, response_type, redirect_uri. Checks the JWT hasn't expired or too far in the future, or is before the nbf claim date.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
IPV-Core will now send its authorize request as a JAR. So the "request" JWT that is sent to the SharedAttributes handler now has additional claims that describe ipv-core as the connecting client. We now need to validate those claims and the JWT to ensure the connecting client can be trusted.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-946](https://govukverify.atlassian.net/browse/PYI-946)
