### PR TITLE
PYIC-948: Create new dynamoDB table to store passport session details…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -187,9 +187,12 @@ Resources:
       Environment:
         Variables:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
+          CRI_PASSPORT_SESSIONS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CriPassportSessionsTable.Arn]]
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${Environment}/credentialIssuers/ukPassport/clients/*"
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CriPassportSessionsTable
       Events:
         IPVCriUKPassportAPI:
           Type: Api
@@ -232,6 +235,18 @@ Resources:
           AttributeType: "S"
       KeySchema:
         - AttributeName: "accessToken"
+          KeyType: "HASH"
+
+  CriPassportSessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "cri-passport-sessions-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "criPassportSessionId"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "criPassportSessionId"
           KeyType: "HASH"
 
 Outputs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Deploy new DynamoDB table to store the new cri passport session data.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The connecting client details from the new JAR requests will now be stored in the back-end. This keeps us inline with the rest of the CRI's and also makes it easier to handle since this information will be decrypted and validated in the back-end and will avoid us from needing to store it and pass the details around in the front-end session.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-948](https://govukverify.atlassian.net/browse/PYI-948)

