### PR TITLE
PYIC-950: Store user_id header value in DCSResponse DynamoDB table

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -36,6 +36,7 @@ public class DateStorePassportCheckIT {
     private static final String RESOURCE_ID_PARAM = "resourceId";
     private static final String ATTRIBUTES_PARAM = "attributes";
     private static final String GPG45_SCORE_PARAM = "gpg45Score";
+    private static final String USER_ID_PARAM = "userId";
     private static final List<String> createdItemIds = new ArrayList<>();
 
     private static DataStore<PassportCheckDao> dcsResponseDataStore;
@@ -94,6 +95,9 @@ public class DateStorePassportCheckIT {
                 OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(GPG45_SCORE_PARAM));
         Evidence savedEvidence = OBJECT_MAPPER.readValue(gpg45ScoreJson, Evidence.class);
         assertEquals(passportCheckDao.getGpg45Score().toString(), savedEvidence.toString());
+
+        String userId = savedPassportCheck.getString(USER_ID_PARAM);
+        assertEquals(passportCheckDao.getUserId(), userId);
     }
 
     @Test
@@ -109,6 +113,7 @@ public class DateStorePassportCheckIT {
                 passportCheckDao.getAttributes().toString(), result.getAttributes().toString());
         assertEquals(
                 passportCheckDao.getGpg45Score().toString(), result.getGpg45Score().toString());
+        assertEquals(passportCheckDao.getUserId(), result.getUserId());
     }
 
     private PassportCheckDao createPassportCheckDao() {
@@ -131,6 +136,6 @@ public class DateStorePassportCheckIT {
         Evidence evidence = new Evidence(5, 5);
         createdItemIds.add(resourceId);
 
-        return new PassportCheckDao(resourceId, passportAttributes, evidence);
+        return new PassportCheckDao(resourceId, passportAttributes, evidence, "test-user-id");
     }
 }

--- a/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidator.java
+++ b/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.passport.authorizationcode.validation;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
@@ -24,10 +25,15 @@ public class AuthRequestValidator {
     }
 
     public Optional<ErrorResponse> validateRequest(
-            Map<String, List<String>> queryStringParameters) {
+            Map<String, List<String>> queryStringParameters, String userId) {
         if (queryStringParamsMissing(queryStringParameters)) {
             LOGGER.error("Missing required query parameters for authorisation request");
             return Optional.of(ErrorResponse.MISSING_QUERY_PARAMETERS);
+        }
+
+        if (StringUtils.isBlank(userId)) {
+            LOGGER.error("Missing user_id header for authorisation request");
+            return Optional.of(ErrorResponse.MISSING_USER_ID_HEADER);
         }
 
         return validateRedirectUrl(queryStringParameters);

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -54,7 +54,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorizationCodeHandlerTest {
-    private static final Map<String, String> TEST_EVENT_HEADERS = Map.of("ipv-session-id", "12345");
+    private static final Map<String, String> TEST_EVENT_HEADERS =
+            Map.of("ipv-session-id", "12345", "user_id", "test-user-id");
     public static final String PASSPORT_NUMBER = "1234567890";
     public static final String SURNAME = "Tattsyrup";
     public static final List<String> FORENAMES = List.of("Tubbs");
@@ -127,7 +128,7 @@ class AuthorizationCodeHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
-        when(authRequestValidator.validateRequest(any())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(any(), anyString())).thenReturn(Optional.empty());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
@@ -136,6 +137,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         var response = underTest.handleRequest(event, context);
@@ -159,7 +161,7 @@ class AuthorizationCodeHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
-        when(authRequestValidator.validateRequest(any())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(any(), anyString())).thenReturn(Optional.empty());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
@@ -168,6 +170,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         var response = underTest.handleRequest(event, context);
@@ -191,11 +194,12 @@ class AuthorizationCodeHandlerTest {
 
     @Test
     void shouldReturn400IfRequestFailsValidation() throws Exception {
-        when(authRequestValidator.validateRequest(anyMap()))
+        when(authRequestValidator.validateRequest(anyMap(), any()))
                 .thenReturn(Optional.of(ErrorResponse.MISSING_QUERY_PARAMETERS));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(new HashMap<>());
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         var response = underTest.handleRequest(event, context);
@@ -214,7 +218,8 @@ class AuthorizationCodeHandlerTest {
 
     @Test
     void shouldReturn400IfDataIsMissing() throws JsonProcessingException {
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
         var formFields = validPassportFormData.keySet();
         for (String keyToRemove : formFields) {
             var event = new APIGatewayProxyRequestEvent();
@@ -224,6 +229,7 @@ class AuthorizationCodeHandlerTest {
             params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
             params.put(OAuth2RequestParams.SCOPE, "openid");
             event.setQueryStringParameters(params);
+            event.setHeaders(Map.of("user_id", "test-user-id"));
             event.setBody(
                     objectMapper.writeValueAsString(
                             new HashMap<>(validPassportFormData).remove(keyToRemove)));
@@ -243,7 +249,8 @@ class AuthorizationCodeHandlerTest {
 
     @Test
     void shouldReturn400IfDateStringsAreWrongFormat() throws JsonProcessingException {
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         var mangledDateInput = new HashMap<>(validPassportFormData);
         mangledDateInput.put("dateOfBirth", "28-09-1984");
@@ -255,6 +262,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(mangledDateInput));
 
         var response = underTest.handleRequest(event, context);
@@ -277,7 +285,8 @@ class AuthorizationCodeHandlerTest {
                 .thenReturn(dcsSignedEncryptedResponse);
         when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
                 .thenReturn(jwsObject);
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         DcsResponse errorDcsResponse =
                 new DcsResponse(
@@ -296,6 +305,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         var response = underTest.handleRequest(event, context);
@@ -321,7 +331,8 @@ class AuthorizationCodeHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
@@ -330,6 +341,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         underTest.handleRequest(event, context);
@@ -366,7 +378,8 @@ class AuthorizationCodeHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(invalidDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
@@ -375,6 +388,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         underTest.handleRequest(event, context);
@@ -411,7 +425,8 @@ class AuthorizationCodeHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
@@ -420,6 +435,7 @@ class AuthorizationCodeHandlerTest {
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
+        event.setHeaders(Map.of("user_id", "test-user-id"));
         event.setBody(objectMapper.writeValueAsString(validPassportFormData));
 
         underTest.handleRequest(event, context);
@@ -448,7 +464,8 @@ class AuthorizationCodeHandlerTest {
     @Test
     void shouldReturn400IfCanNotParseAuthRequestFromQueryStringParams()
             throws JsonProcessingException {
-        when(authRequestValidator.validateRequest(anyMap())).thenReturn(Optional.empty());
+        when(authRequestValidator.validateRequest(anyMap(), anyString()))
+                .thenReturn(Optional.empty());
 
         List<String> paramsToRemove =
                 List.of(

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidatorTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidatorTest.java
@@ -44,14 +44,14 @@ class AuthRequestValidatorTest {
         when(mockConfigurationService.getClientRedirectUrls("12345"))
                 .thenReturn(List.of("http://example.com"));
 
-        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS);
+        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, "test-user-id");
 
         assertFalse(validationResult.isPresent());
     }
 
     @Test
     void validateRequestReturnsErrorResponseForNullParams() {
-        var validationResult = validator.validateRequest(null);
+        var validationResult = validator.validateRequest(null, "test-user-id");
 
         assertTrue(validationResult.isPresent());
         assertEquals(
@@ -63,7 +63,7 @@ class AuthRequestValidatorTest {
 
     @Test
     void validateRequestReturnsErrorResponseForEmptyParameters() {
-        var validationResult = validator.validateRequest(Collections.emptyMap());
+        var validationResult = validator.validateRequest(Collections.emptyMap(), "test-user-id");
 
         assertTrue(validationResult.isPresent());
         assertEquals(
@@ -81,7 +81,7 @@ class AuthRequestValidatorTest {
             invalidQueryStringParams.remove(paramToTest);
 
             Optional<ErrorResponse> validationResult =
-                    validator.validateRequest(invalidQueryStringParams);
+                    validator.validateRequest(invalidQueryStringParams, "test-user-id");
 
             assertTrue(validationResult.isPresent());
             assertEquals(
@@ -103,13 +103,25 @@ class AuthRequestValidatorTest {
         when(mockConfigurationService.getClientRedirectUrls("12345"))
                 .thenReturn(registeredRedirectUrls);
 
-        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS);
+        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, "test-user-id");
 
         assertTrue(validationResult.isPresent());
         assertEquals(
                 ErrorResponse.INVALID_REDIRECT_URL.getCode(), validationResult.get().getCode());
         assertEquals(
                 ErrorResponse.INVALID_REDIRECT_URL.getMessage(),
+                validationResult.get().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnsErrorIfMissingUserId() {
+        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, null);
+
+        assertTrue(validationResult.isPresent());
+        assertEquals(
+                ErrorResponse.MISSING_USER_ID_HEADER.getCode(), validationResult.get().getCode());
+        assertEquals(
+                ErrorResponse.MISSING_USER_ID_HEADER.getMessage(),
                 validationResult.get().getMessage());
     }
 }

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidatorTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/validation/AuthRequestValidatorTest.java
@@ -32,6 +32,8 @@ class AuthRequestValidatorTest {
                     OAuth2RequestParams.RESPONSE_TYPE, List.of("code"),
                     OAuth2RequestParams.SCOPE, List.of("openid"));
 
+    private static final String USER_ID = "test-user-id";
+
     private AuthRequestValidator validator;
 
     @BeforeEach
@@ -44,14 +46,14 @@ class AuthRequestValidatorTest {
         when(mockConfigurationService.getClientRedirectUrls("12345"))
                 .thenReturn(List.of("http://example.com"));
 
-        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, "test-user-id");
+        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, USER_ID);
 
         assertFalse(validationResult.isPresent());
     }
 
     @Test
     void validateRequestReturnsErrorResponseForNullParams() {
-        var validationResult = validator.validateRequest(null, "test-user-id");
+        var validationResult = validator.validateRequest(null, USER_ID);
 
         assertTrue(validationResult.isPresent());
         assertEquals(
@@ -63,7 +65,7 @@ class AuthRequestValidatorTest {
 
     @Test
     void validateRequestReturnsErrorResponseForEmptyParameters() {
-        var validationResult = validator.validateRequest(Collections.emptyMap(), "test-user-id");
+        var validationResult = validator.validateRequest(Collections.emptyMap(), USER_ID);
 
         assertTrue(validationResult.isPresent());
         assertEquals(
@@ -81,7 +83,7 @@ class AuthRequestValidatorTest {
             invalidQueryStringParams.remove(paramToTest);
 
             Optional<ErrorResponse> validationResult =
-                    validator.validateRequest(invalidQueryStringParams, "test-user-id");
+                    validator.validateRequest(invalidQueryStringParams, USER_ID);
 
             assertTrue(validationResult.isPresent());
             assertEquals(
@@ -103,7 +105,7 @@ class AuthRequestValidatorTest {
         when(mockConfigurationService.getClientRedirectUrls("12345"))
                 .thenReturn(registeredRedirectUrls);
 
-        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, "test-user-id");
+        var validationResult = validator.validateRequest(VALID_QUERY_STRING_PARAMS, USER_ID);
 
         assertTrue(validationResult.isPresent());
         assertEquals(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -104,10 +104,12 @@ class IssueCredentialHandlerTest {
 
     private final Evidence evidence = new Evidence(4, 4);
 
+    private final String userId = "test-user-id";
+
     @BeforeEach
     void setUp() throws Exception {
         attributes.setDcsResponse(validDcsResponse);
-        dcsCredential = new PassportCheckDao(TEST_RESOURCE_ID, attributes, evidence);
+        dcsCredential = new PassportCheckDao(TEST_RESOURCE_ID, attributes, evidence, userId);
         responseBody = new HashMap<>();
         ECDSASigner ecSigner = new ECDSASigner(getPrivateKey());
         issueCredentialHandler =

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -37,7 +37,8 @@ class VerifiableCredentialTest {
                         true,
                         false,
                         Collections.emptyList()));
-        PassportCheckDao passportCheckDao = new PassportCheckDao(RESOURCE_ID, attributes, evidence);
+        PassportCheckDao passportCheckDao =
+                new PassportCheckDao(RESOURCE_ID, attributes, evidence, "test-user-id");
 
         VerifiableCredential verifiableCredential =
                 VerifiableCredential.fromPassportCheckDao(passportCheckDao);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -23,7 +23,8 @@ public enum ErrorResponse {
     INVALID_REQUEST_PARAM(1014, "Invalid request param"),
     SHARED_CLAIM_IS_MISSING(1015, "shared_claim missing from shared attribute JWT"),
     FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE(
-            1016, "Failed to send message to aws SQS audit event queue");
+            1016, "Failed to send message to aws SQS audit event queue"),
+    MISSING_USER_ID_HEADER(1017, "Missing user_id header in authorisation request");
 
     private final int code;
     private final String message;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -12,13 +12,16 @@ public class PassportCheckDao {
     private String resourceId;
     private PassportAttributes attributes;
     private Evidence gpg45Score;
+    private String userId;
 
     public PassportCheckDao() {}
 
-    public PassportCheckDao(String resourceId, PassportAttributes attributes, Evidence gpg45Score) {
+    public PassportCheckDao(
+            String resourceId, PassportAttributes attributes, Evidence gpg45Score, String userId) {
         this.resourceId = resourceId;
         this.attributes = attributes;
         this.gpg45Score = gpg45Score;
+        this.userId = userId;
     }
 
     @DynamoDbPartitionKey
@@ -44,5 +47,13 @@ public class PassportCheckDao {
 
     public void setGpg45Score(Evidence gpg45Score) {
         this.gpg45Score = gpg45Score;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
@@ -35,7 +35,11 @@ class DcsPassportCheckServiceTest {
     @Test
     void shouldReturnCredentialsFromDataStore() {
         PassportCheckDao passportCheckDao =
-                new PassportCheckDao(UUID.randomUUID().toString(), passportAttributes, gpg45Score);
+                new PassportCheckDao(
+                        UUID.randomUUID().toString(),
+                        passportAttributes,
+                        gpg45Score,
+                        "test-user-id");
 
         when(mockDataStore.getItem(anyString())).thenReturn(passportCheckDao);
 
@@ -47,5 +51,6 @@ class DcsPassportCheckServiceTest {
         assertEquals(
                 passportCheckDao.getAttributes().getDcsResponse(),
                 credential.getAttributes().getDcsResponse());
+        assertEquals(passportCheckDao.getUserId(), credential.getUserId());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -118,7 +118,8 @@ class PassportServiceTest {
                         LocalDate.now(),
                         LocalDate.now());
         Evidence evidence = new Evidence(4, 4);
-        PassportCheckDao dcsResponse = new PassportCheckDao("UUID", passportAttributes, evidence);
+        PassportCheckDao dcsResponse =
+                new PassportCheckDao("UUID", passportAttributes, evidence, "test-user-id");
         underTest.persistDcsResponse(dcsResponse);
         verify(dataStore).create(dcsResponse);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the AuthorizationCodeHandler lambda to accept a new header "user_id" from passport-front. The value in this header is then stored alongside the passport data from DCS and the passport-front values within the DcsResponse DynamoDB table.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The user_id value is stored in the DB to be used later during the IssueCredential lambda where we generate the VC. The VC will need to include this userId value which it will be able to read off the DCSResponse record.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-950](https://govukverify.atlassian.net/browse/PYI-950)

