### PR TITLE
PYIC-962: Create new KMS RSA decrypter and include in the JAR validation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Integration tests
         env:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
+          JAR_ENCRYPTION_KEY_ID_PARAM: 180539d5-50e0-4984-8000-3aceadc942be
+          JAR_KMS_PUBLIC_KEY_PARAM: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugDcZBuOLGOMbZbmDndZjP0JGGZzsCleOoo2/X8ahXZfFYZ2u1zotnYqQE5QI1BfDNOivw2jYaUcxgudPsqPj8uBfgunA/hnjZ9T5A20g9uRrX0aW5vk629ZU2u2hp64cCkDzrsbq3Iz74STSSA9ZN2HHO+L9qZmNzMp/Vg1jJwGpDsJXxARoCf2GBU8cWy3f1upvcgFR23OVXJO7+ou/9KFSUr7ksagwvrq880wNa7dvbPyQzwZBCuCoGyK2IhkovMeSJPomjKkzC8yS7hA0bai+V/9TiFa68T9nF/oucJIb2CRPvYmI2iScrq4FparBfn2sZH9LBz4EAyvB3TuvQIDAQAB
         run: ./gradlew intTest
 
       - name: SAM validate

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Integration tests
         env:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
-          JAR_ENCRYPTION_KEY_ID_PARAM: 180539d5-50e0-4984-8000-3aceadc942be
-          JAR_KMS_PUBLIC_KEY_PARAM: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugDcZBuOLGOMbZbmDndZjP0JGGZzsCleOoo2/X8ahXZfFYZ2u1zotnYqQE5QI1BfDNOivw2jYaUcxgudPsqPj8uBfgunA/hnjZ9T5A20g9uRrX0aW5vk629ZU2u2hp64cCkDzrsbq3Iz74STSSA9ZN2HHO+L9qZmNzMp/Vg1jJwGpDsJXxARoCf2GBU8cWy3f1upvcgFR23OVXJO7+ou/9KFSUr7ksagwvrq880wNa7dvbPyQzwZBCuCoGyK2IhkovMeSJPomjKkzC8yS7hA0bai+V/9TiFa68T9nF/oucJIb2CRPvYmI2iScrq4FparBfn2sZH9LBz4EAyvB3TuvQIDAQAB
-        run: ./gradlew intTest
+          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
+          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+          run: ./gradlew intTest
 
       - name: SAM validate
         working-directory: ./deploy

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Integration tests
         env:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
+          JAR_ENCRYPTION_KEY_ID_PARAM: 180539d5-50e0-4984-8000-3aceadc942be
+          JAR_KMS_PUBLIC_KEY_PARAM: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugDcZBuOLGOMbZbmDndZjP0JGGZzsCleOoo2/X8ahXZfFYZ2u1zotnYqQE5QI1BfDNOivw2jYaUcxgudPsqPj8uBfgunA/hnjZ9T5A20g9uRrX0aW5vk629ZU2u2hp64cCkDzrsbq3Iz74STSSA9ZN2HHO+L9qZmNzMp/Vg1jJwGpDsJXxARoCf2GBU8cWy3f1upvcgFR23OVXJO7+ou/9KFSUr7ksagwvrq880wNa7dvbPyQzwZBCuCoGyK2IhkovMeSJPomjKkzC8yS7hA0bai+V/9TiFa68T9nF/oucJIb2CRPvYmI2iScrq4FparBfn2sZH9LBz4EAyvB3TuvQIDAQAB
         run: ./gradlew intTest
 
       - name: Perform Static Analysis

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Integration tests
         env:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
-          JAR_ENCRYPTION_KEY_ID_PARAM: 180539d5-50e0-4984-8000-3aceadc942be
-          JAR_KMS_PUBLIC_KEY_PARAM: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugDcZBuOLGOMbZbmDndZjP0JGGZzsCleOoo2/X8ahXZfFYZ2u1zotnYqQE5QI1BfDNOivw2jYaUcxgudPsqPj8uBfgunA/hnjZ9T5A20g9uRrX0aW5vk629ZU2u2hp64cCkDzrsbq3Iz74STSSA9ZN2HHO+L9qZmNzMp/Vg1jJwGpDsJXxARoCf2GBU8cWy3f1upvcgFR23OVXJO7+ou/9KFSUr7ksagwvrq880wNa7dvbPyQzwZBCuCoGyK2IhkovMeSJPomjKkzC8yS7hA0bai+V/9TiFa68T9nF/oucJIb2CRPvYmI2iScrq4FparBfn2sZH9LBz4EAyvB3TuvQIDAQAB
+          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
+          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
         run: ./gradlew intTest
 
       - name: Perform Static Analysis

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -205,6 +205,14 @@ Resources:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+        - Statement:
+            - Sid: jarKmsEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue PassportCriEncryptionKeyArn
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -189,6 +189,9 @@ Resources:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
           PASSPORT_CRI_CLIENT_AUDIENCE: !Sub "/${Environment}/credentialIssuers/ukPassport/self/audienceForClients"
           PASSPORT_CRI_CLIENT_AUTH_MAX_TTL: !Sub "/${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl"
+          JAR_ENCRYPTION_KEY_ID_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId"
+          # for use in the integration-test
+          JAR_KMS_PUBLIC_KEY_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey"
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${Environment}/credentialIssuers/ukPassport/clients/*"
@@ -198,6 +201,10 @@ Resources:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/audienceForClients
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
       Events:
         IPVCriUKPassportAPI:
           Type: Api

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/KmsRsaDecrypterIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/KmsRsaDecrypterIT.java
@@ -1,0 +1,65 @@
+package uk.gov.di.ipv.cri.passport.integrationtest;
+
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.service.KmsRsaDecrypter;
+
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KmsRsaDecrypterIT {
+    private static ConfigurationService configurationService;
+
+    @BeforeAll
+    public static void setup() {
+        configurationService = new ConfigurationService();
+    }
+
+    @Test
+    void decryptWithKms() throws Exception {
+        String getJarKmsEncryptionKeyId = System.getenv("JAR_ENCRYPTION_KEY_ID_PARAM");
+        if (getJarKmsEncryptionKeyId == null) {
+            throw new IllegalArgumentException(
+                    "The environment variable 'JAR_ENCRYPTION_KEY_ID_PARAM' must be provided to run this test");
+        }
+
+        String getJarKmsPublickKey = System.getenv("JAR_KMS_PUBLIC_KEY_PARAM");
+        if (getJarKmsPublickKey == null) {
+            throw new IllegalArgumentException(
+                    "The environment variable 'JAR_KMS_PUBLIC_KEY_PARAM' must be provided to run this test");
+        }
+
+        String kmsId = configurationService.getJarKmsEncryptionKeyId();
+        String pubKey = configurationService.getJarKmsPublickKey();
+
+        var header =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                        .type(new JOSEObjectType("JWE"))
+                        .build();
+        JWEObject jweObject = new JWEObject(header, new Payload("Decrypt me!"));
+
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        RSAPublicKey publicKey =
+                (RSAPublicKey)
+                        keyFactory.generatePublic(
+                                new X509EncodedKeySpec(Base64.getDecoder().decode(pubKey)));
+        jweObject.encrypt(new RSAEncrypter(publicKey));
+
+        jweObject.decrypt(new KmsRsaDecrypter(kmsId));
+        String s = jweObject.getPayload().toString();
+
+        assertEquals("Decrypt me!", s);
+    }
+}

--- a/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
+++ b/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.service.KmsRsaDecrypter;
 import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
 
 import java.security.KeyFactory;
@@ -54,6 +55,8 @@ class JwtAuthorizationRequestHandlerTest {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Mock private ConfigurationService configurationService;
+
+    @Mock private KmsRsaDecrypter kmsRsaDecrypter;
 
     @Mock private JarValidator jarValidator;
 
@@ -91,7 +94,9 @@ class JwtAuthorizationRequestHandlerTest {
         signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
         signedJWT.sign(new ECDSASigner(getPrivateKey()));
 
-        underTest = new JwtAuthorizationRequestHandler(configurationService, jarValidator);
+        underTest =
+                new JwtAuthorizationRequestHandler(
+                        configurationService, kmsRsaDecrypter, jarValidator);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -247,6 +247,14 @@ public class ConfigurationService {
         return ssmProvider.get(System.getenv("VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID_PARAM"));
     }
 
+    public String getJarKmsEncryptionKeyId() {
+        return ssmProvider.get(System.getenv("JAR_ENCRYPTION_KEY_ID_PARAM"));
+    }
+
+    public String getJarKmsPublickKey() {
+        return ssmProvider.get(System.getenv("JAR_KMS_PUBLIC_KEY_PARAM"));
+    }
+
     public long maxJwtTtl() {
         return Long.parseLong(ssmProvider.get(System.getenv("MAX_JWT_TTL")));
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/KmsRsaDecrypter.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/KmsRsaDecrypter.java
@@ -1,0 +1,103 @@
+package uk.gov.di.ipv.cri.passport.library.service;
+
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.kms.model.DecryptRequest;
+import com.amazonaws.services.kms.model.DecryptResult;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEDecrypter;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
+import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
+import com.nimbusds.jose.jca.JWEJCAContext;
+import com.nimbusds.jose.util.Base64URL;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.amazonaws.services.kms.model.EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
+import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP_256;
+
+@ExcludeFromGeneratedCoverageReport
+public class KmsRsaDecrypter implements JWEDecrypter {
+    private static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS = Set.of(JWEAlgorithm.RSA_OAEP_256);
+    private static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS =
+            Set.of(EncryptionMethod.A256GCM);
+
+    private final AWSKMS kmsClient;
+    private final String keyId;
+    private final JWEJCAContext jwejcaContext = new JWEJCAContext();
+
+    public KmsRsaDecrypter(String keyId) {
+        this.keyId = keyId;
+        this.kmsClient = AWSKMSClientBuilder.defaultClient();
+    }
+
+    public KmsRsaDecrypter(String keyId, AWSKMS kmsClient) {
+        this.keyId = keyId;
+        this.kmsClient = kmsClient;
+    }
+
+    @Override
+    public byte[] decrypt(
+            JWEHeader header,
+            Base64URL encryptedKey,
+            Base64URL iv,
+            Base64URL cipherText,
+            Base64URL authTag)
+            throws JOSEException {
+        if (Objects.isNull(encryptedKey)) {
+            throw new JOSEException("Missing JWE encrypted key");
+        }
+
+        if (Objects.isNull(iv)) {
+            throw new JOSEException("Missing JWE initialization vector (IV)");
+        }
+
+        if (Objects.isNull(authTag)) {
+            throw new JOSEException("Missing JWE authentication tag");
+        }
+
+        JWEAlgorithm alg = header.getAlgorithm();
+
+        if (!SUPPORTED_ALGORITHMS.contains(alg)) {
+            throw new JOSEException(
+                    AlgorithmSupportMessage.unsupportedJWEAlgorithm(alg, supportedJWEAlgorithms()));
+        }
+
+        DecryptRequest encryptedKeyDecryptRequest =
+                new DecryptRequest()
+                        .withCiphertextBlob(ByteBuffer.wrap(encryptedKey.decode()))
+                        .withEncryptionAlgorithm(RSAES_OAEP_SHA_256)
+                        .withKeyId(keyId);
+
+        DecryptResult decryptResult = kmsClient.decrypt(encryptedKeyDecryptRequest);
+
+        SecretKeySpec contentEncryptionKey =
+                new SecretKeySpec(decryptResult.getPlaintext().array(), "AES");
+
+        return ContentCryptoProvider.decrypt(
+                header, encryptedKey, iv, cipherText, authTag, contentEncryptionKey, jwejcaContext);
+    }
+
+    @Override
+    public Set<JWEAlgorithm> supportedJWEAlgorithms() {
+        return Set.of(RSA_OAEP_256);
+    }
+
+    @Override
+    public Set<EncryptionMethod> supportedEncryptionMethods() {
+        return SUPPORTED_ENCRYPTION_METHODS;
+    }
+
+    @Override
+    public JWEJCAContext getJCAContext() {
+        return jwejcaContext;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.passport.library.validation;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
@@ -20,7 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.service.KmsRsaDecrypter;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
@@ -37,6 +40,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
@@ -50,6 +54,8 @@ class JarValidatorTest {
 
     @Mock private ConfigurationService configurationService;
 
+    @Mock private KmsRsaDecrypter kmsRsaDecrypter;
+
     private JarValidator jarValidator;
 
     private final String audienceClaim = "test-audience";
@@ -62,7 +68,39 @@ class JarValidatorTest {
 
     @BeforeEach
     void setUp() {
-        jarValidator = new JarValidator(configurationService);
+        jarValidator = new JarValidator(kmsRsaDecrypter, configurationService);
+    }
+
+    @Test
+    void shouldReturnSignedJwtOnSuccessfulDecryption()
+            throws JOSEException, NoSuchAlgorithmException, InvalidKeySpecException, ParseException,
+                    JarValidationException {
+        SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
+        when(kmsRsaDecrypter.decrypt(any(), any(), any(), any(), any()))
+                .thenReturn(signedJWT.serialize().getBytes(StandardCharsets.UTF_8));
+
+        String jweObjectString =
+                "eyJ0eXAiOiJKV0UiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.ZpVOfw61XyBBgsR4CRNRMn2oj_S65pMJO-iaEHpR6QrPcIuD4ysZexolo28vsZyZNR-kfVdw_5CjQanwMS-yw3U3nSUvXUrTs3uco-FSXulIeDYTRbBtQuDyvBMVoos6DyIfC6eBj30GMe5g6DF5KJ1Q0eXQdF0kyM9olg76uYAUqZ5rW52rC_SOHb5_tMj7UbO2IViIStdzLgVfgnJr7Ms4bvG0C8-mk4Otd7m2Km2-DNyGaNuFQSKclAGu7Zgg-qDyhH4V1Z6WUHt79TuG4TxseUr-6oaFFVD23JYSBy7Aypt0321ycq13qcN-PBiOWtumeW5-_CQuHLaPuOc4-w.RO9IB2KcS2hD3dWlKXSreQ.93Ntu3e0vNSYv4hoMwZ3Aw.YRvWo4bwsP_l7dL_29imGg";
+
+        SignedJWT decryptedJwt = jarValidator.decryptJWE(JWEObject.parse(jweObjectString));
+
+        JWTClaimsSet claimsSet = decryptedJwt.getJWTClaimsSet();
+        assertEquals(redirectUriClaim, claimsSet.getStringClaim("redirect_uri"));
+        assertEquals(Collections.singletonList(audienceClaim), claimsSet.getAudience());
+        assertEquals(subjectClaim, claimsSet.getSubject());
+    }
+
+    @Test
+    void shouldThrowExceptionIfDecrptionFails() throws ParseException {
+        String jweObjectString =
+                "eyJ0eXAiOiJKV0UiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.ZpVOfw61XyBBgsR4CRNRMn2oj_S65pMJO-iaEHpR6QrPcIuD4ysZexolo28vsZyZNR-kfVdw_5CjQanwMS-yw3U3nSUvXUrTs3uco-FSXulIeDYTRbBtQuDyvBMVoos6DyIfC6eBj30GMe5g6DF5KJ1Q0eXQdF0kyM9olg76uYAUqZ5rW52rC_SOHb5_tMj7UbO2IViIStdzLgVfgnJr7Ms4bvG0C8-mk4Otd7m2Km2-DNyGaNuFQSKclAGu7Zgg-qDyhH4V1Z6WUHt79TuG4TxseUr-6oaFFVD23JYSBy7Aypt0321ycq13qcN-PBiOWtumeW5-_CQuHLaPuOc4-w.RO9IB2KcS2hD3dWlKXSreQ.93Ntu3e0vNSYv4hoMwZ3Aw.YRvWo4bwsP_l7dL_29imGg";
+        try {
+            jarValidator.decryptJWE(JWEObject.parse(jweObjectString));
+            fail("Should throw a SharedAttributesValidationException");
+        } catch (JarValidationException e) {
+            assertEquals(
+                    OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), e.getErrorObject().getCode());
+        }
     }
 
     @Test


### PR DESCRIPTION
A POC to show that we can decrypt externally encrypted messages with an
RSA key in KMS.

The decrypter uses KMS to decrypt the encrypted key used to actually
encrypt the content of the JWE.

It then delegates to the nimbus ContentCryptoProvider, which the nimbus
provided RSA decrypter uses.

PYIC-962: Add KmsRsaDecrypter to the JarValidator class

Co-authored-by: Chris Wynne [christopher.wynne@digital.cabinet-office.gov.uk](mailto:christopher.wynne@digital.cabinet-office.gov.uk)

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Included the new KmsDecrypter into the JarValidator in order to decrypt the JWE and return a SignedJWT.

Added a new env variable to store the SSM param name of the KmsEncryptionKeyId.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We are using KMS to decrypt the JAR's. This sets a custom Decrypter that uses an RSA key from KMS to decrypt the JAR coming from ipv-core.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-962](https://govukverify.atlassian.net/browse/PYI-962)

