### PR TITLE
PYIC-1066: Lambda and API gateway logs to Splunk

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -20,6 +20,34 @@ Resources:
     Properties:
       Name: IPV CRI UK Passport API Gateway
       StageName: !Sub ${Environment}
+      AccessLogSetting:
+        DestinationArn: !GetAtt IPVCriUKPassportAPILogGroup.Arn
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength":"$context.responseLength"
+          }
+
+  IPVCriUKPassportAPILogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CriPassport-API-GW-AccessLogs
+      RetentionInDays: 14
+
+  IPVCriUKPassportAPILogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriUKPassportAPILogGroup
 
   IPVCriUKPassportIssueCredentialFunction:
     Type: AWS::Serverless::Function
@@ -76,6 +104,19 @@ Resources:
             Path: /credentials/issue
             Method: POST
 
+  IPVCriUKPassportIssueCredentialFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportIssueCredentialFunction}"
+
+  IPVCriUKPassportIssueCredentialFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriUKPassportIssueCredentialFunctionLogGroup
+
   IPVCriUKPassportAccessTokenFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -115,6 +156,19 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /token
             Method: POST
+
+  IPVCriUKPassportAccessTokenFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportAccessTokenFunction}"
+
+  IPVCriUKPassportAccessTokenFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriUKPassportAccessTokenFunctionLogGroup
 
   IPVCriUKPassportAuthorizationCodeFunction:
     Type: AWS::Serverless::Function
@@ -173,6 +227,19 @@ Resources:
             Path: /authorization
             Method: POST
 
+  IPVCriUKPassportAuthorizationCodeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportAuthorizationCodeFunction}"
+
+  IPVCriUKPassportAuthorizationCodeFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriUKPassportAuthorizationCodeFunctionLogGroup
+
   IPVCriUKPassportJwTAuthorizationRequestFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -220,6 +287,19 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /jwt-authorization-request
             Method: POST
+
+  IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportJwTAuthorizationRequestFunction}"
+
+  IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroup
 
   DCSResponseTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
Add CloudFormation resources to start sending our lambda application
logs and API gateway access logs to Splunk.

For the API gateway logs I've reused the JSON format we have defined for
the core-front Fargate API gateway logs, for consistency. The only
difference is the addition of responseLatency which could be helpful
when looking at slow lambdas.

For the lambdas I've explicitly declared a log group resource even
though lambda creates one for you. This is because the lambda created
log groups will store messages indefinitely by default. You can change
this by declaring the log group yourself. As long as the name is the
same as the log group lambda creates and writes to, the function should
write to this new log group. It will be interesting to see if these log
groups deploy cleanly, considering they already exist...

The subscription filters are taking the logs from the newly created log
groups and sending them to Cyber's Centralised Security Logging Service
(CSLS) Kinesis data stream. This is the recommended way of getting our
logs to Splunk. See here for more details:
https://github.com/alphagov/centralised-security-logging-service

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1066](https://govukverify.atlassian.net/browse/PYI-1066)