### PR TITLE
PYIC-1038: Conform to RFC0024

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -86,10 +86,8 @@ public class DateStorePassportCheckIT {
 
         String attributesJson =
                 OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(ATTRIBUTES_PARAM));
-        PassportAttributes savedPassportAttributes =
-                OBJECT_MAPPER.readValue(attributesJson, PassportAttributes.class);
-        assertEquals(
-                passportCheckDao.getAttributes().toString(), savedPassportAttributes.toString());
+        DcsPayload savedDcsPayload = OBJECT_MAPPER.readValue(attributesJson, DcsPayload.class);
+        assertEquals(passportCheckDao.getDcsPayload().toString(), savedDcsPayload.toString());
 
         String gpg45ScoreJson =
                 OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(GPG45_SCORE_PARAM));
@@ -110,7 +108,7 @@ public class DateStorePassportCheckIT {
 
         assertEquals(passportCheckDao.getResourceId(), result.getResourceId());
         assertEquals(
-                passportCheckDao.getAttributes().toString(), result.getAttributes().toString());
+                passportCheckDao.getDcsPayload().toString(), result.getDcsPayload().toString());
         assertEquals(
                 passportCheckDao.getGpg45Score().toString(), result.getGpg45Score().toString());
         assertEquals(passportCheckDao.getUserId(), result.getUserId());
@@ -125,17 +123,17 @@ public class DateStorePassportCheckIT {
                         false,
                         true,
                         null);
-        PassportAttributes passportAttributes =
-                new PassportAttributes(
+        DcsPayload dcsPayload =
+                new DcsPayload(
                         "passport-number",
                         "surname",
                         List.of("family-name"),
                         LocalDate.of(1900, 1, 1),
                         LocalDate.of(2025, 2, 2));
-        passportAttributes.setDcsResponse(dcsResponse);
+        dcsPayload.setDcsResponse(dcsResponse);
         Evidence evidence = new Evidence(5, 5);
         createdItemIds.add(resourceId);
 
-        return new PassportCheckDao(resourceId, passportAttributes, evidence, "test-user-id");
+        return new PassportCheckDao(resourceId, dcsPayload, evidence, "test-user-id");
     }
 }

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -34,8 +34,8 @@ public class DateStorePassportCheckIT {
             new ObjectMapper().registerModule(new JavaTimeModule());
 
     private static final String RESOURCE_ID_PARAM = "resourceId";
-    private static final String ATTRIBUTES_PARAM = "attributes";
-    private static final String GPG45_SCORE_PARAM = "gpg45Score";
+    private static final String DCS_PAYLOAD_PARAM = "dcsPayload";
+    private static final String EVIDENCE_PARAM = "evidence";
     private static final String USER_ID_PARAM = "userId";
     private static final List<String> createdItemIds = new ArrayList<>();
 
@@ -85,14 +85,14 @@ public class DateStorePassportCheckIT {
         assertEquals(passportCheckDao.getResourceId(), savedPassportCheck.get(RESOURCE_ID_PARAM));
 
         String attributesJson =
-                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(ATTRIBUTES_PARAM));
+                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(DCS_PAYLOAD_PARAM));
         DcsPayload savedDcsPayload = OBJECT_MAPPER.readValue(attributesJson, DcsPayload.class);
         assertEquals(passportCheckDao.getDcsPayload().toString(), savedDcsPayload.toString());
 
         String gpg45ScoreJson =
-                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(GPG45_SCORE_PARAM));
+                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(EVIDENCE_PARAM));
         Evidence savedEvidence = OBJECT_MAPPER.readValue(gpg45ScoreJson, Evidence.class);
-        assertEquals(passportCheckDao.getGpg45Score().toString(), savedEvidence.toString());
+        assertEquals(passportCheckDao.getEvidence().toString(), savedEvidence.toString());
 
         String userId = savedPassportCheck.getString(USER_ID_PARAM);
         assertEquals(passportCheckDao.getUserId(), userId);
@@ -109,8 +109,7 @@ public class DateStorePassportCheckIT {
         assertEquals(passportCheckDao.getResourceId(), result.getResourceId());
         assertEquals(
                 passportCheckDao.getDcsPayload().toString(), result.getDcsPayload().toString());
-        assertEquals(
-                passportCheckDao.getGpg45Score().toString(), result.getGpg45Score().toString());
+        assertEquals(passportCheckDao.getEvidence().toString(), result.getEvidence().toString());
         assertEquals(passportCheckDao.getUserId(), result.getUserId());
     }
 
@@ -130,8 +129,7 @@ public class DateStorePassportCheckIT {
                         List.of("family-name"),
                         LocalDate.of(1900, 1, 1),
                         LocalDate.of(2025, 2, 2));
-        dcsPayload.setDcsResponse(dcsResponse);
-        Evidence evidence = new Evidence(5, 5);
+        Evidence evidence = new Evidence(4, 2, UUID.randomUUID().toString());
         createdItemIds.add(resourceId);
 
         return new PassportCheckDao(resourceId, dcsPayload, evidence, "test-user-id");

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -129,7 +129,7 @@ public class DateStorePassportCheckIT {
                         List.of("family-name"),
                         LocalDate.of(1900, 1, 1),
                         LocalDate.of(2025, 2, 2));
-        Evidence evidence = new Evidence(4, 2, UUID.randomUUID().toString());
+        Evidence evidence = new Evidence(UUID.randomUUID(), 4, 2, null);
         createdItemIds.add(resourceId);
 
         return new PassportCheckDao(resourceId, dcsPayload, evidence, "test-user-id");

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -129,7 +129,7 @@ public class DateStorePassportCheckIT {
                         List.of("family-name"),
                         LocalDate.of(1900, 1, 1),
                         LocalDate.of(2025, 2, 2));
-        Evidence evidence = new Evidence(UUID.randomUUID(), 4, 2, null);
+        Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 2, null);
         createdItemIds.add(resourceId);
 
         return new PassportCheckDao(resourceId, dcsPayload, evidence, "test-user-id");

--- a/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
+++ b/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
@@ -116,7 +116,6 @@ public class AuthorizationCodeHandler
             auditService.sendAuditEvent(AuditEventTypes.PASSPORT_REQUEST_SENT_TO_DCS);
 
             DcsResponse unwrappedDcsResponse = unwrapDcsResponse(dcsResponse);
-            dcsPayload.setDcsResponse(unwrappedDcsResponse);
 
             validateDcsResponse(unwrappedDcsResponse);
 
@@ -179,7 +178,8 @@ public class AuthorizationCodeHandler
                         ? MAX_PASSPORT_GPG45_VALIDITY_VALUE
                         : MIN_PASSPORT_GPG45_VALUE;
 
-        return new Evidence(MAX_PASSPORT_GPG45_STRENGTH_VALUE, validity);
+        return new Evidence(
+                MAX_PASSPORT_GPG45_STRENGTH_VALUE, validity, UUID.randomUUID().toString());
     }
 
     private DcsPayload parsePassportFormRequest(String input)

--- a/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
+++ b/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
@@ -175,7 +175,7 @@ public class AuthorizationCodeHandler
 
     private Evidence generateGpg45Score(DcsResponse dcsResponse) {
         return new Evidence(
-                UUID.randomUUID(),
+                UUID.randomUUID().toString(),
                 MAX_PASSPORT_GPG45_STRENGTH_VALUE,
                 calculateValidity(dcsResponse),
                 calculateContraIndicators(dcsResponse));

--- a/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
+++ b/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.ContraIndicators;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.EmptyDcsResponseException;
@@ -173,13 +174,11 @@ public class AuthorizationCodeHandler
     }
 
     private Evidence generateGpg45Score(DcsResponse dcsResponse) {
-        int validity =
-                dcsResponse.isValid()
-                        ? MAX_PASSPORT_GPG45_VALIDITY_VALUE
-                        : MIN_PASSPORT_GPG45_VALUE;
-
         return new Evidence(
-                MAX_PASSPORT_GPG45_STRENGTH_VALUE, validity, UUID.randomUUID().toString());
+                UUID.randomUUID(),
+                MAX_PASSPORT_GPG45_STRENGTH_VALUE,
+                calculateValidity(dcsResponse),
+                calculateContraIndicators(dcsResponse));
     }
 
     private DcsPayload parsePassportFormRequest(String input)
@@ -238,5 +237,13 @@ public class AuthorizationCodeHandler
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_UNWRAP_DCS_RESPONSE);
         }
+    }
+
+    private int calculateValidity(DcsResponse dcsResponse) {
+        return dcsResponse.isValid() ? MAX_PASSPORT_GPG45_VALIDITY_VALUE : MIN_PASSPORT_GPG45_VALUE;
+    }
+
+    private List<ContraIndicators> calculateContraIndicators(DcsResponse dcsResponse) {
+        return dcsResponse.isValid() ? null : List.of(ContraIndicators.D02);
     }
 }

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -354,11 +354,11 @@ class AuthorizationCodeHandlerTest {
                 validPassportFormData.get("passportNumber"),
                 persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
-                VALID_PASSPORT_EVIDENCE.getStrength(),
-                persistedPassportCheckDao.getValue().getEvidence().getStrength());
+                VALID_PASSPORT_EVIDENCE.getStrengthScore(),
+                persistedPassportCheckDao.getValue().getEvidence().getStrengthScore());
         assertEquals(
-                VALID_PASSPORT_EVIDENCE.getValidity(),
-                persistedPassportCheckDao.getValue().getEvidence().getValidity());
+                VALID_PASSPORT_EVIDENCE.getValidityScore(),
+                persistedPassportCheckDao.getValue().getEvidence().getValidityScore());
         assertNull(persistedPassportCheckDao.getValue().getEvidence().getCi());
     }
 
@@ -398,11 +398,11 @@ class AuthorizationCodeHandlerTest {
                 validPassportFormData.get("passportNumber"),
                 persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
-                INVALID_PASSPORT_EVIDENCE.getStrength(),
-                persistedPassportCheckDao.getValue().getEvidence().getStrength());
+                INVALID_PASSPORT_EVIDENCE.getStrengthScore(),
+                persistedPassportCheckDao.getValue().getEvidence().getStrengthScore());
         assertEquals(
-                INVALID_PASSPORT_EVIDENCE.getValidity(),
-                persistedPassportCheckDao.getValue().getEvidence().getValidity());
+                INVALID_PASSPORT_EVIDENCE.getValidityScore(),
+                persistedPassportCheckDao.getValue().getEvidence().getValidityScore());
         assertEquals(
                 INVALID_PASSPORT_EVIDENCE.getCi(),
                 persistedPassportCheckDao.getValue().getEvidence().getCi());

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -19,9 +19,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.authorizationcode.validation.AuthRequestValidator;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.EmptyDcsResponseException;
@@ -123,8 +123,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
@@ -156,8 +155,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
@@ -283,8 +281,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(authRequestValidator.validateRequest(anyMap(), anyString()))
                 .thenReturn(Optional.empty());
 
@@ -326,8 +323,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
@@ -352,7 +348,7 @@ class AuthorizationCodeHandlerTest {
         verify(passportService).persistDcsResponse(persistedPassportCheckDao.capture());
         assertEquals(
                 validPassportFormData.get("passportNumber"),
-                persistedPassportCheckDao.getValue().getAttributes().getPassportNumber());
+                persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
                 VALID_GPG45_SCORE.getStrength(),
                 persistedPassportCheckDao.getValue().getGpg45Score().getStrength());
@@ -361,7 +357,7 @@ class AuthorizationCodeHandlerTest {
                 persistedPassportCheckDao.getValue().getGpg45Score().getValidity());
         assertEquals(
                 validDcsResponse,
-                persistedPassportCheckDao.getValue().getAttributes().getDcsResponse());
+                persistedPassportCheckDao.getValue().getDcsPayload().getDcsResponse());
     }
 
     @Test
@@ -373,8 +369,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(invalidDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
@@ -399,7 +394,7 @@ class AuthorizationCodeHandlerTest {
         verify(passportService).persistDcsResponse(persistedPassportCheckDao.capture());
         assertEquals(
                 validPassportFormData.get("passportNumber"),
-                persistedPassportCheckDao.getValue().getAttributes().getPassportNumber());
+                persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
                 INVALID_GPG45_SCORE.getStrength(),
                 persistedPassportCheckDao.getValue().getGpg45Score().getStrength());
@@ -408,7 +403,7 @@ class AuthorizationCodeHandlerTest {
                 persistedPassportCheckDao.getValue().getGpg45Score().getValidity());
         assertEquals(
                 invalidDcsResponse,
-                persistedPassportCheckDao.getValue().getAttributes().getDcsResponse());
+                persistedPassportCheckDao.getValue().getDcsPayload().getDcsResponse());
     }
 
     @Test
@@ -420,8 +415,7 @@ class AuthorizationCodeHandlerTest {
                 new DcsSignedEncryptedResponse("TEST_PAYLOAD");
         when(passportService.dcsPassportCheck(any(JWSObject.class)))
                 .thenReturn(dcsSignedEncryptedResponse);
-        when(dcsCryptographyService.preparePayload(any(PassportAttributes.class)))
-                .thenReturn(jwsObject);
+        when(dcsCryptographyService.preparePayload(any(DcsPayload.class))).thenReturn(jwsObject);
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -61,8 +61,10 @@ class AuthorizationCodeHandlerTest {
     public static final List<String> FORENAMES = List.of("Tubbs");
     public static final String DATE_OF_BIRTH = "1984-09-28";
     public static final String EXPIRY_DATE = "2024-09-03";
-    public static final Evidence VALID_GPG45_SCORE = new Evidence(4, 2);
-    public static final Evidence INVALID_GPG45_SCORE = new Evidence(4, 0);
+    public static final Evidence VALID_GPG45_SCORE =
+            new Evidence(4, 2, UUID.randomUUID().toString());
+    public static final Evidence INVALID_GPG45_SCORE =
+            new Evidence(4, 0, UUID.randomUUID().toString());
     private static final Map<String, String> VALID_QUERY_PARAMS =
             Map.of(
                     OAuth2RequestParams.REDIRECT_URI, "http://example.com",
@@ -351,13 +353,11 @@ class AuthorizationCodeHandlerTest {
                 persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
                 VALID_GPG45_SCORE.getStrength(),
-                persistedPassportCheckDao.getValue().getGpg45Score().getStrength());
+                persistedPassportCheckDao.getValue().getEvidence().getStrength());
         assertEquals(
                 VALID_GPG45_SCORE.getValidity(),
-                persistedPassportCheckDao.getValue().getGpg45Score().getValidity());
-        assertEquals(
-                validDcsResponse,
-                persistedPassportCheckDao.getValue().getDcsPayload().getDcsResponse());
+                persistedPassportCheckDao.getValue().getEvidence().getValidity());
+        ;
     }
 
     @Test
@@ -397,13 +397,11 @@ class AuthorizationCodeHandlerTest {
                 persistedPassportCheckDao.getValue().getDcsPayload().getPassportNumber());
         assertEquals(
                 INVALID_GPG45_SCORE.getStrength(),
-                persistedPassportCheckDao.getValue().getGpg45Score().getStrength());
+                persistedPassportCheckDao.getValue().getEvidence().getStrength());
         assertEquals(
                 INVALID_GPG45_SCORE.getValidity(),
-                persistedPassportCheckDao.getValue().getGpg45Score().getValidity());
-        assertEquals(
-                invalidDcsResponse,
-                persistedPassportCheckDao.getValue().getDcsPayload().getDcsResponse());
+                persistedPassportCheckDao.getValue().getEvidence().getValidity());
+        ;
     }
 
     @Test

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -64,9 +64,9 @@ class AuthorizationCodeHandlerTest {
     public static final String DATE_OF_BIRTH = "1984-09-28";
     public static final String EXPIRY_DATE = "2024-09-03";
     public static final Evidence VALID_PASSPORT_EVIDENCE =
-            new Evidence(UUID.randomUUID(), 4, 2, null);
+            new Evidence(UUID.randomUUID().toString(), 4, 2, null);
     public static final Evidence INVALID_PASSPORT_EVIDENCE =
-            new Evidence(UUID.randomUUID(), 4, 0, List.of(ContraIndicators.D02));
+            new Evidence(UUID.randomUUID().toString(), 4, 0, List.of(ContraIndicators.D02));
     private static final Map<String, String> VALID_QUERY_PARAMS =
             Map.of(
                     OAuth2RequestParams.REDIRECT_URI, "http://example.com",

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -145,7 +145,7 @@ public class IssueCredentialHandler
                         .claim(
                                 EXPIRATION_TIME,
                                 now.plusSeconds(configurationService.maxJwtTtl()).getEpochSecond())
-                        .claim(VC_CLAIM, objectMapper.writeValueAsString(verifiableCredential))
+                        .claim(VC_CLAIM, verifiableCredential)
                         .build();
 
         return JwtHelper.createSignedJwtFromClaimSet(claimsSet, kmsSigner);

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -4,8 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -45,7 +43,6 @@ public class IssueCredentialHandler
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IssueCredentialHandler.class);
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final DcsPassportCheckService dcsPassportCheckService;
     private final AccessTokenService accessTokenService;
@@ -118,7 +115,7 @@ public class IssueCredentialHandler
             LOGGER.error("Failed to parse access token");
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());
-        } catch (JOSEException | JsonProcessingException e) {
+        } catch (JOSEException e) {
             LOGGER.error("Failed to sign verifiable credential: '{}'", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     OAuth2Error.SERVER_ERROR.getHTTPStatusCode(),
@@ -134,8 +131,7 @@ public class IssueCredentialHandler
     }
 
     private SignedJWT generateAndSignVerifiableCredentialJwt(
-            VerifiableCredential verifiableCredential, String subject)
-            throws JOSEException, JsonProcessingException {
+            VerifiableCredential verifiableCredential, String subject) throws JOSEException {
         Instant now = Instant.now();
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -36,13 +36,7 @@ import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 import static com.nimbusds.jwt.JWTClaimNames.SUBJECT;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.DI_CONTEXT;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CONTEXT;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_TYPE;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
-import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.W3_BASE_CONTEXT;
 
 public class IssueCredentialHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -147,12 +141,6 @@ public class IssueCredentialHandler
                         .claim(
                                 EXPIRATION_TIME,
                                 now.plusSeconds(configurationService.maxJwtTtl()).getEpochSecond())
-                        .claim(VC_CONTEXT, new String[] {W3_BASE_CONTEXT, DI_CONTEXT})
-                        .claim(
-                                VC_TYPE,
-                                new String[] {
-                                    VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
-                                })
                         .claim(VC_CLAIM, verifiableCredential)
                         .build();
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -169,7 +169,7 @@ class IssueCredentialHandlerTest {
         VerifiableCredential verifiableCredential =
                 objectMapper.convertValue(vcNode, VerifiableCredential.class);
         List<NameParts> nameParts =
-                verifiableCredential.getCredentialSubject().getName().getNameParts();
+                verifiableCredential.getCredentialSubject().getName().get(0).getNameParts();
 
         assertEquals(passportCheckDao.getUserId(), claimsSet.get("sub").asText());
 
@@ -203,15 +203,19 @@ class IssueCredentialHandlerTest {
 
         assertEquals(
                 passportCheckDao.getDcsPayload().getDateOfBirth().toString(),
-                verifiableCredential.getCredentialSubject().getBirthDate().getValue());
+                verifiableCredential.getCredentialSubject().getBirthDate().get(0).getValue());
 
         assertEquals(
                 passportCheckDao.getDcsPayload().getPassportNumber(),
-                verifiableCredential.getCredentialSubject().getPassport().getDocumentNumber());
+                verifiableCredential
+                        .getCredentialSubject()
+                        .getPassport()
+                        .get(0)
+                        .getDocumentNumber());
 
         assertEquals(
                 passportCheckDao.getDcsPayload().getExpiryDate().toString(),
-                verifiableCredential.getCredentialSubject().getPassport().getExpiryDate());
+                verifiableCredential.getCredentialSubject().getPassport().get(0).getExpiryDate());
 
         assertEquals(
                 passportCheckDao.getEvidence().getTxn(),

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -226,11 +226,11 @@ class IssueCredentialHandlerTest {
                 verifiableCredential.getEvidence().get(0).getType());
 
         assertEquals(
-                passportCheckDao.getEvidence().getStrength(),
-                verifiableCredential.getEvidence().get(0).getStrength());
+                passportCheckDao.getEvidence().getStrengthScore(),
+                verifiableCredential.getEvidence().get(0).getStrengthScore());
         assertEquals(
-                passportCheckDao.getEvidence().getValidity(),
-                verifiableCredential.getEvidence().get(0).getValidity());
+                passportCheckDao.getEvidence().getValidityScore(),
+                verifiableCredential.getEvidence().get(0).getValidityScore());
 
         assertNull(verifiableCredential.getEvidence().get(0).getCi());
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -100,7 +100,7 @@ class IssueCredentialHandlerTest {
                     LocalDate.parse(DATE_OF_BIRTH),
                     LocalDate.parse(EXPIRY_DATE));
 
-    private final Evidence evidence = new Evidence(UUID.randomUUID(), 4, 2, null);
+    private final Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 2, null);
 
     private final String userId = "test-user-id";
 
@@ -167,7 +167,7 @@ class IssueCredentialHandlerTest {
 
         JsonNode vcNode = claimsSet.get("vc");
         VerifiableCredential verifiableCredential =
-                objectMapper.readValue(vcNode.asText(), VerifiableCredential.class);
+                objectMapper.convertValue(vcNode, VerifiableCredential.class);
         List<NameParts> nameParts =
                 verifiableCredential.getCredentialSubject().getName().getNameParts();
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -54,6 +54,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -99,7 +100,7 @@ class IssueCredentialHandlerTest {
                     LocalDate.parse(DATE_OF_BIRTH),
                     LocalDate.parse(EXPIRY_DATE));
 
-    private final Evidence evidence = new Evidence(4, 2, UUID.randomUUID().toString());
+    private final Evidence evidence = new Evidence(UUID.randomUUID(), 4, 2, null);
 
     private final String userId = "test-user-id";
 
@@ -166,8 +167,7 @@ class IssueCredentialHandlerTest {
 
         JsonNode vcNode = claimsSet.get("vc");
         VerifiableCredential verifiableCredential =
-                objectMapper.convertValue(vcNode, VerifiableCredential.class);
-
+                objectMapper.readValue(vcNode.asText(), VerifiableCredential.class);
         List<NameParts> nameParts =
                 verifiableCredential.getCredentialSubject().getName().getNameParts();
 
@@ -227,6 +227,8 @@ class IssueCredentialHandlerTest {
         assertEquals(
                 passportCheckDao.getEvidence().getValidity(),
                 verifiableCredential.getEvidence().get(0).getValidity());
+
+        assertNull(verifiableCredential.getEvidence().get(0).getCi());
 
         ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK_1));
         assertTrue(signedJWT.verify(ecVerifier));

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NamePartType;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NameParts;
@@ -94,8 +94,8 @@ class IssueCredentialHandlerTest {
             new DcsResponse(
                     UUID.randomUUID().toString(), UUID.randomUUID().toString(), false, true, null);
 
-    private final PassportAttributes attributes =
-            new PassportAttributes(
+    private final DcsPayload attributes =
+            new DcsPayload(
                     PASSPORT_NUMBER,
                     SURNAME,
                     FORENAMES,
@@ -184,7 +184,7 @@ class IssueCredentialHandlerTest {
                                                 .and(
                                                         hasValue(
                                                                 dcsCredential
-                                                                        .getAttributes()
+                                                                        .getDcsPayload()
                                                                         .getSurname()))
                                                 .test(o)));
         assertTrue(
@@ -195,25 +195,25 @@ class IssueCredentialHandlerTest {
                                                 .and(
                                                         hasValue(
                                                                 dcsCredential
-                                                                        .getAttributes()
+                                                                        .getDcsPayload()
                                                                         .getForenames()
                                                                         .get(0)))
                                                 .test(o)));
 
         assertEquals(
-                dcsCredential.getAttributes().getPassportNumber(),
+                dcsCredential.getDcsPayload().getPassportNumber(),
                 verifiableCredential.getCredentialSubject().getPassportNumber());
         assertEquals(
-                dcsCredential.getAttributes().getDateOfBirth().toString(),
+                dcsCredential.getDcsPayload().getDateOfBirth().toString(),
                 verifiableCredential.getCredentialSubject().getBirthDate().getValue());
         assertEquals(
-                dcsCredential.getAttributes().getExpiryDate().toString(),
+                dcsCredential.getDcsPayload().getExpiryDate().toString(),
                 verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
-                dcsCredential.getAttributes().getRequestId().toString(),
+                dcsCredential.getDcsPayload().getRequestId().toString(),
                 verifiableCredential.getCredentialSubject().getRequestId());
         assertEquals(
-                dcsCredential.getAttributes().getCorrelationId().toString(),
+                dcsCredential.getDcsPayload().getCorrelationId().toString(),
                 verifiableCredential.getCredentialSubject().getCorrelationId());
         assertEquals(
                 dcsCredential.getGpg45Score().getStrength(),

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -76,8 +76,8 @@ class VerifiableCredentialTest {
                 () ->
                         UUID.fromString(
                                 verifiableCredential.getEvidence().get(0).getTxn().toString()));
-        assertEquals(4, verifiableCredential.getEvidence().get(0).getStrength());
-        assertEquals(2, verifiableCredential.getEvidence().get(0).getValidity());
+        assertEquals(4, verifiableCredential.getEvidence().get(0).getStrengthScore());
+        assertEquals(2, verifiableCredential.getEvidence().get(0).getValidityScore());
     }
 
     @Test
@@ -105,8 +105,8 @@ class VerifiableCredentialTest {
                         + "  \"evidence\" : [ {\n"
                         + "    \"type\" : \"IdentityCheck\",\n"
                         + "    \"txn\" : \"b46cbad4-2680-433f-b12c-b09fc27f281f\",\n"
-                        + "    \"strength\" : 4,\n"
-                        + "    \"validity\" : 2\n"
+                        + "    \"strengthScore\" : 4,\n"
+                        + "    \"validityScore\" : 2\n"
                         + "  } ],\n"
                         + "  \"type\" : [ \"VerifiableCredential\", \"IdentityCheckCredential\" ]\n"
                         + "}";
@@ -153,8 +153,8 @@ class VerifiableCredentialTest {
                         + "  \"evidence\" : [ {\n"
                         + "    \"type\" : \"IdentityCheck\",\n"
                         + "    \"txn\" : \"b46cbad4-2680-433f-b12c-b09fc27f281f\",\n"
-                        + "    \"strength\" : 4,\n"
-                        + "    \"validity\" : 2,\n"
+                        + "    \"strengthScore\" : 4,\n"
+                        + "    \"validityScore\" : 2,\n"
                         + "    \"ci\" : [ \"D02\" ]\n"
                         + "  } ],\n"
                         + "  \"type\" : [ \"VerifiableCredential\", \"IdentityCheckCredential\" ]\n"

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -1,8 +1,8 @@
 package uk.gov.di.ipv.cri.passport.issuecredential.domain;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredential;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -26,8 +26,8 @@ class VerifiableCredentialTest {
     @Test
     void shouldConvertPassportCheckDaoToPassportCredentialIssuerResponse() {
 
-        PassportAttributes attributes =
-                new PassportAttributes(
+        DcsPayload attributes =
+                new DcsPayload(
                         PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
         Evidence evidence = new Evidence(4, 4);
         attributes.setDcsResponse(
@@ -68,13 +68,13 @@ class VerifiableCredentialTest {
                 EXPIRY_DATE.toString(),
                 verifiableCredential.getCredentialSubject().getExpiryDate());
         assertEquals(
-                passportCheckDao.getAttributes().getRequestId().toString(),
+                passportCheckDao.getDcsPayload().getRequestId().toString(),
                 verifiableCredential.getCredentialSubject().getRequestId());
         assertEquals(
-                passportCheckDao.getAttributes().getCorrelationId().toString(),
+                passportCheckDao.getDcsPayload().getCorrelationId().toString(),
                 verifiableCredential.getCredentialSubject().getCorrelationId());
         assertEquals(
-                passportCheckDao.getAttributes().getDcsResponse(),
+                passportCheckDao.getDcsPayload().getDcsResponse(),
                 verifiableCredential.getCredentialSubject().getDcsResponse());
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -32,7 +32,7 @@ class VerifiableCredentialTest {
                 new DcsPayload(
                         PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
 
-        Evidence evidence = new Evidence(UUID.randomUUID(), 4, 2, null);
+        Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 2, null);
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(RESOURCE_ID, dcsPayload, evidence, "test-user-id");
 
@@ -108,8 +108,7 @@ class VerifiableCredentialTest {
         DcsPayload dcsPayload =
                 new DcsPayload(
                         PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
-        Evidence evidence =
-                new Evidence(UUID.fromString("b46cbad4-2680-433f-b12c-b09fc27f281f"), 4, 2, null);
+        Evidence evidence = new Evidence("b46cbad4-2680-433f-b12c-b09fc27f281f", 4, 2, null);
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(RESOURCE_ID, dcsPayload, evidence, "test-user-id");
 
@@ -160,7 +159,7 @@ class VerifiableCredentialTest {
                         PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
         Evidence evidence =
                 new Evidence(
-                        UUID.fromString("b46cbad4-2680-433f-b12c-b09fc27f281f"),
+                        "b46cbad4-2680-433f-b12c-b09fc27f281f",
                         4,
                         2,
                         List.of(ContraIndicators.D02));

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -44,6 +44,7 @@ class VerifiableCredentialTest {
                 verifiableCredential
                         .getCredentialSubject()
                         .getName()
+                        .get(0)
                         .getNameParts()
                         .get(1)
                         .getValue());
@@ -52,18 +53,23 @@ class VerifiableCredentialTest {
                 verifiableCredential
                         .getCredentialSubject()
                         .getName()
+                        .get(0)
                         .getNameParts()
                         .get(0)
                         .getValue());
         assertEquals(
                 DATE_OF_BIRTH.toString(),
-                verifiableCredential.getCredentialSubject().getBirthDate().getValue());
+                verifiableCredential.getCredentialSubject().getBirthDate().get(0).getValue());
         assertEquals(
                 PASSPORT_NUMBER,
-                verifiableCredential.getCredentialSubject().getPassport().getDocumentNumber());
+                verifiableCredential
+                        .getCredentialSubject()
+                        .getPassport()
+                        .get(0)
+                        .getDocumentNumber());
         assertEquals(
                 EXPIRY_DATE.toString(),
-                verifiableCredential.getCredentialSubject().getPassport().getExpiryDate());
+                verifiableCredential.getCredentialSubject().getPassport().get(0).getExpiryDate());
         assertEquals(
                 EVIDENCE_TYPE_IDENTITY_CHECK, verifiableCredential.getEvidence().get(0).getType());
         assertDoesNotThrow(
@@ -79,7 +85,7 @@ class VerifiableCredentialTest {
         String expectedJson =
                 "{\n"
                         + "  \"credentialSubject\" : {\n"
-                        + "    \"name\" : {\n"
+                        + "    \"name\" : [ {\n"
                         + "      \"nameParts\" : [ {\n"
                         + "        \"type\" : \"GivenName\",\n"
                         + "        \"value\" : \"givenNames\"\n"
@@ -87,14 +93,14 @@ class VerifiableCredentialTest {
                         + "        \"type\" : \"FamilyName\",\n"
                         + "        \"value\" : \"familyName\"\n"
                         + "      } ]\n"
-                        + "    },\n"
-                        + "    \"birthDate\" : {\n"
+                        + "    } ],\n"
+                        + "    \"birthDate\" : [ {\n"
                         + "      \"value\" : \"1984-09-28\"\n"
-                        + "    },\n"
-                        + "    \"passport\" : {\n"
+                        + "    } ],\n"
+                        + "    \"passport\" : [ {\n"
                         + "      \"documentNumber\" : \"passportNumber\",\n"
                         + "      \"expiryDate\" : \"2034-09-28\"\n"
-                        + "    }\n"
+                        + "    } ]\n"
                         + "  },\n"
                         + "  \"evidence\" : [ {\n"
                         + "    \"type\" : \"IdentityCheck\",\n"
@@ -127,7 +133,7 @@ class VerifiableCredentialTest {
         String expectedJson =
                 "{\n"
                         + "  \"credentialSubject\" : {\n"
-                        + "    \"name\" : {\n"
+                        + "    \"name\" : [ {\n"
                         + "      \"nameParts\" : [ {\n"
                         + "        \"type\" : \"GivenName\",\n"
                         + "        \"value\" : \"givenNames\"\n"
@@ -135,14 +141,14 @@ class VerifiableCredentialTest {
                         + "        \"type\" : \"FamilyName\",\n"
                         + "        \"value\" : \"familyName\"\n"
                         + "      } ]\n"
-                        + "    },\n"
-                        + "    \"birthDate\" : {\n"
+                        + "    } ],\n"
+                        + "    \"birthDate\" : [ {\n"
                         + "      \"value\" : \"1984-09-28\"\n"
-                        + "    },\n"
-                        + "    \"passport\" : {\n"
+                        + "    } ],\n"
+                        + "    \"passport\" : [ {\n"
                         + "      \"documentNumber\" : \"passportNumber\",\n"
                         + "      \"expiryDate\" : \"2034-09-28\"\n"
-                        + "    }\n"
+                        + "    } ]\n"
                         + "  },\n"
                         + "  \"evidence\" : [ {\n"
                         + "    \"type\" : \"IdentityCheck\",\n"

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsPayload.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsPayload.java
@@ -25,7 +25,6 @@ public class DcsPayload {
     @JsonProperty private String timestamp;
     @JsonProperty private String passportNumber;
     @JsonProperty private String surname;
-    @JsonProperty private DcsResponse dcsResponse;
 
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
     public List<String> forenames;
@@ -95,14 +94,6 @@ public class DcsPayload {
         this.surname = surname;
     }
 
-    public DcsResponse getDcsResponse() {
-        return dcsResponse;
-    }
-
-    public void setDcsResponse(DcsResponse dcsResponse) {
-        this.dcsResponse = dcsResponse;
-    }
-
     public List<String> getForenames() {
         return forenames;
     }
@@ -136,15 +127,10 @@ public class DcsPayload {
                 + requestId
                 + ", timestamp='"
                 + timestamp
-                + '\''
                 + ", passportNumber='"
                 + passportNumber
-                + '\''
                 + ", surname='"
                 + surname
-                + '\''
-                + ", dcsResponse="
-                + (dcsResponse != null ? dcsResponse : "empty")
                 + ", forenames="
                 + forenames
                 + ", dateOfBirth="

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsPayload.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsPayload.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
-public class PassportAttributes {
+public class DcsPayload {
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
@@ -36,10 +36,10 @@ public class PassportAttributes {
     @JsonFormat(pattern = DATE_FORMAT, timezone = TIME_ZONE)
     public LocalDate expiryDate;
 
-    public PassportAttributes() {}
+    public DcsPayload() {}
 
     @JsonCreator
-    public PassportAttributes(
+    public DcsPayload(
             @JsonProperty(value = "passportNumber", required = true) String passportNumber,
             @JsonProperty(value = "surname", required = true) String surname,
             @JsonProperty(value = "forenames", required = true) List<String> forenames,

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/DcsResponse.java
@@ -60,7 +60,7 @@ public class DcsResponse {
         return valid;
     }
 
-    public void setValid(boolean valid) {
+    public void setValid(Boolean valid) {
         this.valid = valid;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/ContraIndicators.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/ContraIndicators.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
+
+public enum ContraIndicators {
+    D02
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
@@ -1,126 +1,35 @@
 package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 
 public class CredentialSubject {
 
-    @JsonProperty private final Name name;
-    @JsonProperty private final String passportNumber;
+    private final Name name;
 
-    @JsonProperty
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private final BirthDate birthDate;
 
-    @JsonProperty
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private final String expiryDate;
+    private final Passport passport;
 
-    @JsonProperty private final String requestId;
-    @JsonProperty private final String correlationId;
-    @JsonProperty private final DcsResponse dcsResponse;
-
-    @JsonCreator
     public CredentialSubject(
             @JsonProperty(value = "name", required = true) Name name,
-            @JsonProperty(value = "passportNumber", required = true) String passportNumber,
             @JsonProperty(value = "birthDate", required = true) BirthDate birthDate,
-            @JsonProperty(value = "expiryDate", required = true) String expiryDate,
-            @JsonProperty(value = "requestId", required = true) String requestId,
-            @JsonProperty(value = "correlationId", required = true) String correlationId,
-            @JsonProperty(value = "dcsResponse", required = true) DcsResponse dcsResponse) {
+            @JsonProperty(value = "passport", required = true) Passport passport) {
         this.name = name;
-        this.passportNumber = passportNumber;
         this.birthDate = birthDate;
-        this.expiryDate = expiryDate;
-        this.requestId = requestId;
-        this.correlationId = correlationId;
-        this.dcsResponse = dcsResponse;
+        this.passport = passport;
     }
 
     public Name getName() {
         return name;
     }
 
-    public String getPassportNumber() {
-        return passportNumber;
-    }
-
     public BirthDate getBirthDate() {
         return birthDate;
     }
 
-    public String getExpiryDate() {
-        return expiryDate;
-    }
-
-    public String getRequestId() {
-        return requestId;
-    }
-
-    public String getCorrelationId() {
-        return correlationId;
-    }
-
-    public DcsResponse getDcsResponse() {
-        return dcsResponse;
-    }
-
-    public static class Builder {
-        private Name name;
-        private String passportNumber;
-        private BirthDate birthDate;
-        private String expiryDate;
-        private String requestId;
-        private String correlationId;
-        private DcsResponse dcsResponse;
-
-        public Builder setName(Name name) {
-            this.name = name;
-            return this;
-        }
-
-        public Builder setPassportNumber(String passportNumber) {
-            this.passportNumber = passportNumber;
-            return this;
-        }
-
-        public Builder setBirthDate(BirthDate birthDate) {
-            this.birthDate = birthDate;
-            return this;
-        }
-
-        public Builder setExpiryDate(String expiryDate) {
-            this.expiryDate = expiryDate;
-            return this;
-        }
-
-        public Builder setRequestId(String requestId) {
-            this.requestId = requestId;
-            return this;
-        }
-
-        public Builder setCorrelationId(String correlationId) {
-            this.correlationId = correlationId;
-            return this;
-        }
-
-        public Builder setDcsResponse(DcsResponse dcsResponse) {
-            this.dcsResponse = dcsResponse;
-            return this;
-        }
-
-        public CredentialSubject build() {
-            return new CredentialSubject(
-                    name,
-                    passportNumber,
-                    birthDate,
-                    expiryDate,
-                    requestId,
-                    correlationId,
-                    dcsResponse);
-        }
+    public Passport getPassport() {
+        return passport;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/CredentialSubject.java
@@ -3,33 +3,35 @@ package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class CredentialSubject {
 
-    private final Name name;
+    private final List<Name> name;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private final BirthDate birthDate;
+    private final List<BirthDate> birthDate;
 
-    private final Passport passport;
+    private final List<Passport> passport;
 
     public CredentialSubject(
-            @JsonProperty(value = "name", required = true) Name name,
-            @JsonProperty(value = "birthDate", required = true) BirthDate birthDate,
-            @JsonProperty(value = "passport", required = true) Passport passport) {
+            @JsonProperty(value = "name", required = true) List<Name> name,
+            @JsonProperty(value = "birthDate", required = true) List<BirthDate> birthDate,
+            @JsonProperty(value = "passport", required = true) List<Passport> passport) {
         this.name = name;
         this.birthDate = birthDate;
         this.passport = passport;
     }
 
-    public Name getName() {
+    public List<Name> getName() {
         return name;
     }
 
-    public BirthDate getBirthDate() {
+    public List<BirthDate> getBirthDate() {
         return birthDate;
     }
 
-    public Passport getPassport() {
+    public List<Passport> getPassport() {
         return passport;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
@@ -1,19 +1,43 @@
 package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.EVIDENCE_TYPE_IDENTITY_CHECK;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 public class Evidence {
+
+    private String type = EVIDENCE_TYPE_IDENTITY_CHECK;
+    private String txn;
     private int strength;
     private int validity;
 
-    public Evidence() {}
-
-    public Evidence(int strength, int validity) {
+    public Evidence(
+            @JsonProperty("strength") int strength,
+            @JsonProperty("validity") int validity,
+            @JsonProperty("txn") String txn) {
         this.strength = strength;
         this.validity = validity;
+        this.txn = txn;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTxn() {
+        return txn;
+    }
+
+    public void setTxn(String txn) {
+        this.txn = txn;
     }
 
     public int getStrength() {
@@ -34,6 +58,15 @@ public class Evidence {
 
     @Override
     public String toString() {
-        return "Gpg45Evidence{" + "strength=" + strength + ", validity=" + validity + '}';
+        return "Evidence{"
+                + "type="
+                + type
+                + ", txn="
+                + txn
+                + ", strength="
+                + strength
+                + ", validity="
+                + validity
+                + '}';
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
@@ -5,7 +5,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.List;
-import java.util.UUID;
 
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.EVIDENCE_TYPE_IDENTITY_CHECK;
 
@@ -15,14 +14,14 @@ import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Ver
 public class Evidence {
 
     private String type = EVIDENCE_TYPE_IDENTITY_CHECK;
-    private UUID txn;
+    private String txn;
     private int strength;
     private int validity;
     private List<ContraIndicators> ci;
 
     public Evidence() {}
 
-    public Evidence(UUID txn, int strength, int validity, List<ContraIndicators> ci) {
+    public Evidence(String txn, int strength, int validity, List<ContraIndicators> ci) {
         this.txn = txn;
         this.strength = strength;
         this.validity = validity;
@@ -37,11 +36,11 @@ public class Evidence {
         this.type = type;
     }
 
-    public UUID getTxn() {
+    public String getTxn() {
         return txn;
     }
 
-    public void setTxn(UUID txn) {
+    public void setTxn(String txn) {
         this.txn = txn;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
@@ -1,27 +1,32 @@
 package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.List;
+import java.util.UUID;
 
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.EVIDENCE_TYPE_IDENTITY_CHECK;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Evidence {
 
     private String type = EVIDENCE_TYPE_IDENTITY_CHECK;
-    private String txn;
+    private UUID txn;
     private int strength;
     private int validity;
+    private List<ContraIndicators> ci;
 
-    public Evidence(
-            @JsonProperty("strength") int strength,
-            @JsonProperty("validity") int validity,
-            @JsonProperty("txn") String txn) {
+    public Evidence() {}
+
+    public Evidence(UUID txn, int strength, int validity, List<ContraIndicators> ci) {
+        this.txn = txn;
         this.strength = strength;
         this.validity = validity;
-        this.txn = txn;
+        this.ci = ci;
     }
 
     public String getType() {
@@ -32,11 +37,11 @@ public class Evidence {
         this.type = type;
     }
 
-    public String getTxn() {
+    public UUID getTxn() {
         return txn;
     }
 
-    public void setTxn(String txn) {
+    public void setTxn(UUID txn) {
         this.txn = txn;
     }
 
@@ -56,6 +61,14 @@ public class Evidence {
         this.validity = validity;
     }
 
+    public List<ContraIndicators> getCi() {
+        return ci;
+    }
+
+    public void setCi(List<ContraIndicators> ci) {
+        this.ci = ci;
+    }
+
     @Override
     public String toString() {
         return "Evidence{"
@@ -67,6 +80,8 @@ public class Evidence {
                 + strength
                 + ", validity="
                 + validity
+                + ", ci="
+                + ci
                 + '}';
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Evidence.java
@@ -15,16 +15,16 @@ public class Evidence {
 
     private String type = EVIDENCE_TYPE_IDENTITY_CHECK;
     private String txn;
-    private int strength;
-    private int validity;
+    private int strengthScore;
+    private int validityScore;
     private List<ContraIndicators> ci;
 
     public Evidence() {}
 
-    public Evidence(String txn, int strength, int validity, List<ContraIndicators> ci) {
+    public Evidence(String txn, int strengthScore, int validityScore, List<ContraIndicators> ci) {
         this.txn = txn;
-        this.strength = strength;
-        this.validity = validity;
+        this.strengthScore = strengthScore;
+        this.validityScore = validityScore;
         this.ci = ci;
     }
 
@@ -44,20 +44,20 @@ public class Evidence {
         this.txn = txn;
     }
 
-    public int getStrength() {
-        return strength;
+    public int getStrengthScore() {
+        return strengthScore;
     }
 
-    public void setStrength(int strength) {
-        this.strength = strength;
+    public void setStrengthScore(int strengthScore) {
+        this.strengthScore = strengthScore;
     }
 
-    public int getValidity() {
-        return validity;
+    public int getValidityScore() {
+        return validityScore;
     }
 
-    public void setValidity(int validity) {
-        this.validity = validity;
+    public void setValidityScore(int validityScore) {
+        this.validityScore = validityScore;
     }
 
     public List<ContraIndicators> getCi() {
@@ -76,9 +76,9 @@ public class Evidence {
                 + ", txn="
                 + txn
                 + ", strength="
-                + strength
+                + strengthScore
                 + ", validity="
-                + validity
+                + validityScore
                 + ", ci="
                 + ci
                 + '}';

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/NameParts.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/NameParts.java
@@ -9,21 +9,10 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 public class NameParts {
     private String value;
     private String type;
-    private String validFrom;
-    private String validUntil;
 
     public NameParts(
-            @JsonProperty(value = "value", required = true) String value,
             @JsonProperty(value = "type", required = true) String type,
-            @JsonProperty(value = "validFrom") String validFrom,
-            @JsonProperty(value = "validUntil") String validUntil) {
-        this.value = value;
-        this.type = type;
-        this.validFrom = validFrom;
-        this.validUntil = validUntil;
-    }
-
-    public NameParts(String type, String value) {
+            @JsonProperty(value = "value", required = true) String value) {
         this.value = value;
         this.type = type;
     }
@@ -44,37 +33,8 @@ public class NameParts {
         this.type = type;
     }
 
-    public String getValidFrom() {
-        return validFrom;
-    }
-
-    public void setValidFrom(String validFrom) {
-        this.validFrom = validFrom;
-    }
-
-    public String getValidUntil() {
-        return validUntil;
-    }
-
-    public void setValidUntil(String validUntil) {
-        this.validUntil = validUntil;
-    }
-
     @Override
     public String toString() {
-        return "NameParts{"
-                + "value='"
-                + value
-                + '\''
-                + ", type='"
-                + type
-                + '\''
-                + ", validFrom='"
-                + validFrom
-                + '\''
-                + ", validUntil='"
-                + validUntil
-                + '\''
-                + '}';
+        return "NameParts{" + "value='" + value + '\'' + ", type='" + type + '\'' + '}';
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Passport.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Passport.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Passport {
+    private String documentNumber;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private String expiryDate;
+
+    public Passport(
+            @JsonProperty(value = "documentNumber") String documentNumber,
+            @JsonProperty(value = "expiryDate") String expiryDate) {
+        this.documentNumber = documentNumber;
+        this.expiryDate = expiryDate;
+    }
+
+    public String getDocumentNumber() {
+        return documentNumber;
+    }
+
+    public void setDocumentNumber(String documentNumber) {
+        this.documentNumber = documentNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -24,7 +24,7 @@ public class VerifiableCredential {
 
         // Add Forenames to NameParts
         passportCheck
-                .getAttributes()
+                .getDcsPayload()
                 .getForenames()
                 .forEach(
                         givenName ->
@@ -36,20 +36,20 @@ public class VerifiableCredential {
         nameParts.add(
                 new NameParts(
                         NamePartType.FAMILY_NAME.getName(),
-                        passportCheck.getAttributes().getSurname()));
+                        passportCheck.getDcsPayload().getSurname()));
 
         CredentialSubject credentialSubject =
                 new CredentialSubject.Builder()
                         .setName(new Name(nameParts))
-                        .setPassportNumber(passportCheck.getAttributes().getPassportNumber())
+                        .setPassportNumber(passportCheck.getDcsPayload().getPassportNumber())
                         .setBirthDate(
                                 new BirthDate(
-                                        passportCheck.getAttributes().getDateOfBirth().toString()))
-                        .setExpiryDate(passportCheck.getAttributes().getExpiryDate().toString())
-                        .setRequestId(passportCheck.getAttributes().getRequestId().toString())
+                                        passportCheck.getDcsPayload().getDateOfBirth().toString()))
+                        .setExpiryDate(passportCheck.getDcsPayload().getExpiryDate().toString())
+                        .setRequestId(passportCheck.getDcsPayload().getRequestId().toString())
                         .setCorrelationId(
-                                passportCheck.getAttributes().getCorrelationId().toString())
-                        .setDcsResponse(passportCheck.getAttributes().getDcsResponse())
+                                passportCheck.getDcsPayload().getCorrelationId().toString())
+                        .setDcsResponse(passportCheck.getDcsPayload().getDcsResponse())
                         .build();
 
         return new VerifiableCredential(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -45,11 +45,14 @@ public class VerifiableCredential {
 
         CredentialSubject credentialSubject =
                 new CredentialSubject(
-                        new Name(nameParts),
-                        new BirthDate(passportCheck.getDcsPayload().getDateOfBirth().toString()),
-                        new Passport(
-                                passportCheck.getDcsPayload().getPassportNumber(),
-                                passportCheck.getDcsPayload().getExpiryDate().toString()));
+                        List.of(new Name(nameParts)),
+                        List.of(
+                                new BirthDate(
+                                        passportCheck.getDcsPayload().getDateOfBirth().toString())),
+                        List.of(
+                                new Passport(
+                                        passportCheck.getDcsPayload().getPassportNumber(),
+                                        passportCheck.getDcsPayload().getExpiryDate().toString())));
 
         return new VerifiableCredential(
                 credentialSubject, Collections.singletonList(passportCheck.getEvidence()));

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -7,14 +7,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
+import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
+
 public class VerifiableCredential {
 
-    @JsonProperty private CredentialSubject credentialSubject;
-    @JsonProperty private List<Evidence> evidence;
+    private final List<String> type =
+            List.of(VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE);
+    private final CredentialSubject credentialSubject;
+    private final List<Evidence> evidence;
 
-    public VerifiableCredential() {}
-
-    public VerifiableCredential(CredentialSubject credentialSubject, List<Evidence> evidence) {
+    public VerifiableCredential(
+            @JsonProperty("credentialSubject") CredentialSubject credentialSubject,
+            @JsonProperty("evidence") List<Evidence> evidence) {
         this.credentialSubject = credentialSubject;
         this.evidence = evidence;
     }
@@ -39,21 +44,19 @@ public class VerifiableCredential {
                         passportCheck.getDcsPayload().getSurname()));
 
         CredentialSubject credentialSubject =
-                new CredentialSubject.Builder()
-                        .setName(new Name(nameParts))
-                        .setPassportNumber(passportCheck.getDcsPayload().getPassportNumber())
-                        .setBirthDate(
-                                new BirthDate(
-                                        passportCheck.getDcsPayload().getDateOfBirth().toString()))
-                        .setExpiryDate(passportCheck.getDcsPayload().getExpiryDate().toString())
-                        .setRequestId(passportCheck.getDcsPayload().getRequestId().toString())
-                        .setCorrelationId(
-                                passportCheck.getDcsPayload().getCorrelationId().toString())
-                        .setDcsResponse(passportCheck.getDcsPayload().getDcsResponse())
-                        .build();
+                new CredentialSubject(
+                        new Name(nameParts),
+                        new BirthDate(passportCheck.getDcsPayload().getDateOfBirth().toString()),
+                        new Passport(
+                                passportCheck.getDcsPayload().getPassportNumber(),
+                                passportCheck.getDcsPayload().getExpiryDate().toString()));
 
         return new VerifiableCredential(
-                credentialSubject, Collections.singletonList(passportCheck.getGpg45Score()));
+                credentialSubject, Collections.singletonList(passportCheck.getEvidence()));
+    }
+
+    public List<String> getType() {
+        return type;
     }
 
     public CredentialSubject getCredentialSubject() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredentialConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredentialConstants.java
@@ -1,19 +1,10 @@
 package uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential;
 
 public class VerifiableCredentialConstants {
-    public static final String VC_CONTEXT = "@context";
-    public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
-    public static final String DI_CONTEXT =
-            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
-    public static final String VC_TYPE = "type";
     public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     public static final String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";
-    public static final String CREDENTIAL_SUBJECT_NAME = "name";
-    public static final String CREDENTIAL_SUBJECT_BIRTH_DATE = "birthDate";
-    public static final String CREDENTIAL_SUBJECT_ADDRESS = "address";
-    public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
-    public static final String VC_EVIDENCE = "evidence";
     public static final String VC_CLAIM = "vc";
+    public static final String EVIDENCE_TYPE_IDENTITY_CHECK = "IdentityCheck";
 
     private VerifiableCredentialConstants() {}
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -11,16 +11,16 @@ import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 public class PassportCheckDao {
     private String resourceId;
     private DcsPayload dcsPayload;
-    private Evidence gpg45Score;
+    private Evidence evidence;
     private String userId;
 
     public PassportCheckDao() {}
 
     public PassportCheckDao(
-            String resourceId, DcsPayload dcsPayload, Evidence gpg45Score, String userId) {
+            String resourceId, DcsPayload dcsPayload, Evidence evidence, String userId) {
         this.resourceId = resourceId;
         this.dcsPayload = dcsPayload;
-        this.gpg45Score = gpg45Score;
+        this.evidence = evidence;
         this.userId = userId;
     }
 
@@ -41,12 +41,12 @@ public class PassportCheckDao {
         this.dcsPayload = dcsPayload;
     }
 
-    public Evidence getGpg45Score() {
-        return gpg45Score;
+    public Evidence getEvidence() {
+        return evidence;
     }
 
-    public void setGpg45Score(Evidence gpg45Score) {
-        this.gpg45Score = gpg45Score;
+    public void setEvidence(Evidence evidence) {
+        this.evidence = evidence;
     }
 
     public String getUserId() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -3,23 +3,23 @@ package uk.gov.di.ipv.cri.passport.library.persistence.item;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 public class PassportCheckDao {
     private String resourceId;
-    private PassportAttributes attributes;
+    private DcsPayload dcsPayload;
     private Evidence gpg45Score;
     private String userId;
 
     public PassportCheckDao() {}
 
     public PassportCheckDao(
-            String resourceId, PassportAttributes attributes, Evidence gpg45Score, String userId) {
+            String resourceId, DcsPayload dcsPayload, Evidence gpg45Score, String userId) {
         this.resourceId = resourceId;
-        this.attributes = attributes;
+        this.dcsPayload = dcsPayload;
         this.gpg45Score = gpg45Score;
         this.userId = userId;
     }
@@ -33,12 +33,12 @@ public class PassportCheckDao {
         this.resourceId = resourceId;
     }
 
-    public PassportAttributes getAttributes() {
-        return attributes;
+    public DcsPayload getDcsPayload() {
+        return dcsPayload;
     }
 
-    public void setAttributes(PassportAttributes passportAttributes) {
-        this.attributes = passportAttributes;
+    public void setDcsPayload(DcsPayload dcsPayload) {
+        this.dcsPayload = dcsPayload;
     }
 
     public Evidence getGpg45Score() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyService.java
@@ -19,9 +19,9 @@ import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.RSAEncrypter;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.ProtectedHeader;
 import uk.gov.di.ipv.cri.passport.library.domain.Thumbprints;
 import uk.gov.di.ipv.cri.passport.library.exceptions.IpvCryptoException;
@@ -44,7 +44,7 @@ public class DcsCryptographyService {
         this.configurationService = configurationService;
     }
 
-    public JWSObject preparePayload(PassportAttributes passportDetails)
+    public JWSObject preparePayload(DcsPayload passportDetails)
             throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
                     JOSEException, JsonProcessingException {
         JWSObject signedPassportDetails =

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -56,14 +56,17 @@ class JwtHelperTest {
         VerifiableCredential verifiableCredential =
                 new VerifiableCredential(
                         new CredentialSubject(
-                                new Name(
-                                        List.of(
-                                                new NameParts(
-                                                        NamePartType.GIVEN_NAME.getName(),
-                                                        GIVEN_NAME))),
-                                new BirthDate(BIRTH_DATE),
-                                new Passport(
-                                        PASSPORT_NUMBER, LocalDate.parse(EXPIRY_DATE).toString())),
+                                List.of(
+                                        new Name(
+                                                List.of(
+                                                        new NameParts(
+                                                                NamePartType.GIVEN_NAME.getName(),
+                                                                GIVEN_NAME)))),
+                                List.of(new BirthDate(BIRTH_DATE)),
+                                List.of(
+                                        new Passport(
+                                                PASSPORT_NUMBER,
+                                                LocalDate.parse(EXPIRY_DATE).toString()))),
                         Collections.singletonList(
                                 new Evidence(UUID.randomUUID().toString(), 4, 2, null)));
 
@@ -89,13 +92,13 @@ class JwtHelperTest {
         JsonNode birthDateNode = credentialSubjectNode.get("birthDate");
         JsonNode passportNode = credentialSubjectNode.get("passport");
 
-        assertEquals(GIVEN_NAME, nameNode.get("nameParts").get(0).get("value").asText());
+        assertEquals(GIVEN_NAME, nameNode.get(0).get("nameParts").get(0).get("value").asText());
         assertEquals(
                 NamePartType.GIVEN_NAME.getName(),
-                nameNode.get("nameParts").get(0).get("type").asText());
-        assertEquals(BIRTH_DATE, birthDateNode.get("value").asText());
-        assertEquals(PASSPORT_NUMBER, passportNode.get("documentNumber").asText());
-        assertEquals(EXPIRY_DATE, passportNode.get("expiryDate").asText());
+                nameNode.get(0).get("nameParts").get(0).get("type").asText());
+        assertEquals(BIRTH_DATE, birthDateNode.get(0).get("value").asText());
+        assertEquals(PASSPORT_NUMBER, passportNode.get(0).get("documentNumber").asText());
+        assertEquals(EXPIRY_DATE, passportNode.get(0).get("expiryDate").asText());
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -64,7 +64,8 @@ class JwtHelperTest {
                                 new BirthDate(BIRTH_DATE),
                                 new Passport(
                                         PASSPORT_NUMBER, LocalDate.parse(EXPIRY_DATE).toString())),
-                        Collections.singletonList(new Evidence(UUID.randomUUID(), 4, 2, null)));
+                        Collections.singletonList(
+                                new Evidence(UUID.randomUUID().toString(), 4, 2, null)));
 
         JWTClaimsSet testClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -12,13 +12,13 @@ import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.BirthDate;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.CredentialSubject;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Name;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NamePartType;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NameParts;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Passport;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredential;
 
 import java.security.KeyFactory;
@@ -42,9 +42,7 @@ import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.E
 @ExtendWith(MockitoExtension.class)
 class JwtHelperTest {
     public static final String BIRTH_DATE = "2020-02-03";
-    public static final String PASSPORT_NUMBER = "passportNumber";
-    public static final String VALID_FROM = "2020-03-03";
-    public static final String VALID_UNTIL = "2021-04-04";
+    public static final String PASSPORT_NUMBER = "123456789";
     public static final String GIVEN_NAME = "Paul";
     public static final String EXPIRY_DATE = "2020-01-01";
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -61,17 +59,13 @@ class JwtHelperTest {
                                 new Name(
                                         List.of(
                                                 new NameParts(
-                                                        GIVEN_NAME,
                                                         NamePartType.GIVEN_NAME.getName(),
-                                                        VALID_FROM,
-                                                        VALID_UNTIL))),
-                                PASSPORT_NUMBER,
+                                                        GIVEN_NAME))),
                                 new BirthDate(BIRTH_DATE),
-                                LocalDate.parse(EXPIRY_DATE).toString(),
-                                UUID.randomUUID().toString(),
-                                UUID.randomUUID().toString(),
-                                new DcsResponse()),
-                        Collections.singletonList(new Evidence()));
+                                new Passport(
+                                        PASSPORT_NUMBER, LocalDate.parse(EXPIRY_DATE).toString())),
+                        Collections.singletonList(
+                                new Evidence(4, 2, UUID.randomUUID().toString())));
 
         JWTClaimsSet testClaimsSet =
                 new JWTClaimsSet.Builder()
@@ -92,15 +86,16 @@ class JwtHelperTest {
         JsonNode vcNode = claimsSet.get("vc");
         JsonNode credentialSubjectNode = vcNode.get("credentialSubject");
         JsonNode nameNode = credentialSubjectNode.get("name");
+        JsonNode birthDateNode = credentialSubjectNode.get("birthDate");
+        JsonNode passportNode = credentialSubjectNode.get("passport");
 
         assertEquals(GIVEN_NAME, nameNode.get("nameParts").get(0).get("value").asText());
         assertEquals(
                 NamePartType.GIVEN_NAME.getName(),
                 nameNode.get("nameParts").get(0).get("type").asText());
-        assertEquals(VALID_FROM, nameNode.get("nameParts").get(0).get("validFrom").asText());
-        assertEquals(VALID_UNTIL, nameNode.get("nameParts").get(0).get("validUntil").asText());
-        assertEquals(BIRTH_DATE, credentialSubjectNode.get("birthDate").get("value").asText());
-        assertEquals(EXPIRY_DATE, credentialSubjectNode.get("expiryDate").asText());
+        assertEquals(BIRTH_DATE, birthDateNode.get("value").asText());
+        assertEquals(PASSPORT_NUMBER, passportNode.get("documentNumber").asText());
+        assertEquals(EXPIRY_DATE, passportNode.get("expiryDate").asText());
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -64,8 +64,7 @@ class JwtHelperTest {
                                 new BirthDate(BIRTH_DATE),
                                 new Passport(
                                         PASSPORT_NUMBER, LocalDate.parse(EXPIRY_DATE).toString())),
-                        Collections.singletonList(
-                                new Evidence(4, 2, UUID.randomUUID().toString())));
+                        Collections.singletonList(new Evidence(UUID.randomUUID(), 4, 2, null)));
 
         JWTClaimsSet testClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsCryptographyServiceTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.Thumbprints;
 import uk.gov.di.ipv.cri.passport.library.exceptions.IpvCryptoException;
 import uk.gov.di.ipv.cri.passport.library.utils.TestUtils;
@@ -89,14 +89,14 @@ class DcsCryptographyServiceTest {
                 .thenReturn(new Thumbprints(SHA_1_THUMBPRINT, SHA_256_THUMBPRINT));
         when(configurationService.getDcsEncryptionCert()).thenReturn(getEncryptionCertificate());
 
-        PassportAttributes passportAttributes =
-                new PassportAttributes(
+        DcsPayload dcsPayload =
+                new DcsPayload(
                         "PASSPORT_NUMBER",
                         "SURNAME",
                         List.of("FORENAMES"),
                         LocalDate.now(),
                         LocalDate.now());
-        JWSObject preparedPayload = underTest.preparePayload(passportAttributes);
+        JWSObject preparedPayload = underTest.preparePayload(dcsPayload);
 
         JWSVerifier verifier =
                 new RSASSAVerifier((RSAPublicKey) getSigningPublicKey(getSigningPrivateKey()));
@@ -110,7 +110,7 @@ class DcsCryptographyServiceTest {
                 JWSObject.parse(encryptedContents.getPayload().toString());
 
         assertTrue(decryptedPassportDetails.verify(verifier));
-        String expected = objectMapper.writeValueAsString(passportAttributes);
+        String expected = objectMapper.writeValueAsString(dcsPayload);
         assertEquals(expected, decryptedPassportDetails.getPayload().toString());
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -21,7 +21,7 @@ class DcsPassportCheckServiceTest {
 
     @Mock private DataStore<PassportCheckDao> mockDataStore;
 
-    @Mock PassportAttributes passportAttributes;
+    @Mock DcsPayload dcsPayload;
 
     @Mock Evidence gpg45Score;
 
@@ -36,10 +36,7 @@ class DcsPassportCheckServiceTest {
     void shouldReturnCredentialsFromDataStore() {
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(
-                        UUID.randomUUID().toString(),
-                        passportAttributes,
-                        gpg45Score,
-                        "test-user-id");
+                        UUID.randomUUID().toString(), dcsPayload, gpg45Score, "test-user-id");
 
         when(mockDataStore.getItem(anyString())).thenReturn(passportCheckDao);
 
@@ -47,10 +44,10 @@ class DcsPassportCheckServiceTest {
                 dcsPassportCheckService.getDcsPassportCheck("dcs-credential-id-1");
 
         assertEquals(passportCheckDao.getResourceId(), credential.getResourceId());
-        assertEquals(passportCheckDao.getAttributes(), credential.getAttributes());
+        assertEquals(passportCheckDao.getDcsPayload(), credential.getDcsPayload());
         assertEquals(
-                passportCheckDao.getAttributes().getDcsResponse(),
-                credential.getAttributes().getDcsResponse());
+                passportCheckDao.getDcsPayload().getDcsResponse(),
+                credential.getDcsPayload().getDcsResponse());
         assertEquals(passportCheckDao.getUserId(), credential.getUserId());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
@@ -23,7 +23,7 @@ class DcsPassportCheckServiceTest {
 
     @Mock DcsPayload dcsPayload;
 
-    @Mock Evidence gpg45Score;
+    @Mock Evidence evidence;
 
     private DcsPassportCheckService dcsPassportCheckService;
 
@@ -36,7 +36,7 @@ class DcsPassportCheckServiceTest {
     void shouldReturnCredentialsFromDataStore() {
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(
-                        UUID.randomUUID().toString(), dcsPayload, gpg45Score, "test-user-id");
+                        UUID.randomUUID().toString(), dcsPayload, evidence, "test-user-id");
 
         when(mockDataStore.getItem(anyString())).thenReturn(passportCheckDao);
 
@@ -45,9 +45,6 @@ class DcsPassportCheckServiceTest {
 
         assertEquals(passportCheckDao.getResourceId(), credential.getResourceId());
         assertEquals(passportCheckDao.getDcsPayload(), credential.getDcsPayload());
-        assertEquals(
-                passportCheckDao.getDcsPayload().getDcsResponse(),
-                credential.getDcsPayload().getDcsResponse());
         assertEquals(passportCheckDao.getUserId(), credential.getUserId());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -16,8 +16,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
-import uk.gov.di.ipv.cri.passport.library.domain.PassportAttributes;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.exceptions.EmptyDcsResponseException;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
@@ -110,8 +110,8 @@ class PassportServiceTest {
 
     @Test
     void shouldCreateDcsResponseInDataStore() {
-        PassportAttributes passportAttributes =
-                new PassportAttributes(
+        DcsPayload dcsPayload =
+                new DcsPayload(
                         "PASSPORT_NUMBER",
                         "SURNAME",
                         List.of("FORENAMES"),
@@ -119,7 +119,7 @@ class PassportServiceTest {
                         LocalDate.now());
         Evidence evidence = new Evidence(4, 4);
         PassportCheckDao dcsResponse =
-                new PassportCheckDao("UUID", passportAttributes, evidence, "test-user-id");
+                new PassportCheckDao("UUID", dcsPayload, evidence, "test-user-id");
         underTest.persistDcsResponse(dcsResponse);
         verify(dataStore).create(dcsResponse);
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -118,7 +118,7 @@ class PassportServiceTest {
                         List.of("FORENAMES"),
                         LocalDate.now(),
                         LocalDate.now());
-        Evidence evidence = new Evidence(4, 4, UUID.randomUUID().toString());
+        Evidence evidence = new Evidence(UUID.randomUUID(), 4, 4, null);
         PassportCheckDao dcsResponse =
                 new PassportCheckDao("UUID", dcsPayload, evidence, "test-user-id");
         underTest.persistDcsResponse(dcsResponse);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -118,7 +118,7 @@ class PassportServiceTest {
                         List.of("FORENAMES"),
                         LocalDate.now(),
                         LocalDate.now());
-        Evidence evidence = new Evidence(UUID.randomUUID(), 4, 4, null);
+        Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 4, null);
         PassportCheckDao dcsResponse =
                 new PassportCheckDao("UUID", dcsPayload, evidence, "test-user-id");
         underTest.persistDcsResponse(dcsResponse);

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -117,7 +118,7 @@ class PassportServiceTest {
                         List.of("FORENAMES"),
                         LocalDate.now(),
                         LocalDate.now());
-        Evidence evidence = new Evidence(4, 4);
+        Evidence evidence = new Evidence(4, 4, UUID.randomUUID().toString());
         PassportCheckDao dcsResponse =
                 new PassportCheckDao("UUID", dcsPayload, evidence, "test-user-id");
         underTest.persistDcsResponse(dcsResponse);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Conform to [RFC0024](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md#identity-rfc-0024-verifiable-credentials-for-identity-checks)

### Why did it change
  
[PYIC-1038: Rename PassportAttributes to DcsPayload](https://github.com/alphagov/di-ipv-cri-uk-passport-back/commit/346f07e02e040323d20f5e5e3888c33da3058c9a) 

The PassportAttributes class contained more than just passport
attributes. Things like correlation ID and request IDs are specific to
DCS. This class is better names as DcsPayload.
  
[PYIC-1038: Return VC that conforms to RFC0024](https://github.com/alphagov/di-ipv-cri-uk-passport-back/commit/170608b6b32667cb041fc50e017b46cd06135d6e) 

Update the VC returned by passport CRI to match the spec defined in
RFC0024:

https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md

The structure defined requires much less data than what we were
previously putting in it. This also makes a few other changes of note.

The `@context` attribute of the credential subject is no longer
required.

The credential subject now includes a passport attribute which contains
the passport number and expiry. This is modeled with a domain object.

The evidence object now contains a `txn` and `type` field.

The `validFrom` and `validUntil` attributes of the credential subject name
parts are not required and have been removed.

The DcsResponse is no longer stored in the DcsPayload. We only really
need the true/false value returned by DCS to generate a GPG45 score. We
don't care about the other data. We will include a contra-indicator in
future however.

The PassportCheckDao `gpg45Score` field has been renamed to `evidence`
to remain consistent with the data model.
  
[PYIC-1038: Return contra indicator for invalid passport](https://github.com/alphagov/di-ipv-cri-uk-passport-back/commit/5c566e1b8afda8ca5f9319b8a3ba1061d6f2773d) 

RFC0024 shows that we need to be returning contra indicators when there
is an issue with a passport. Currently there is only one CI we can
return due to the limited nature of the response from DCS.

[PYIC-1038: Make credential subject properties lists](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/127/commits/6f049167b44919c2de40638ce0519e7e7c873bf8) 
RFC0024 shows that the values of the properties within the credential
subject object should be lists.

[PYIC-1038: Set txn to String type](https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/127/commits/a78e41981510cdf7f2767c3bc4b73625f3d58a4a) 
The Nimbus lib uses it's own json stringifier which struggles to
correctly deserialize a UUID. It converts it to an empty JSON object,
rather than a string representation of the UUID. For some reason.

This causes the core to get upset when trying to deserilize an issued
credential.

Passing in the txn this way also makes for looser coupling and
potentially easier testing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1038](https://govukverify.atlassian.net/browse/PYI-1038)

### Screenshot of returned credential
![staging-di-ipv-orchestrator-stub london cloudapps digital_callback_code=gGiL-kbWCbDcuAinko6tS4CAaR-jv2h5aZorQyMIYeg state=-PTE74TpNJOKbG7E8Rf5HvGvrUCz4zRXRGgbBns_FwQ(iPhone 12 Pro)](https://user-images.githubusercontent.com/13836290/167609783-bfcd3407-fa7e-43ba-aa3a-6d6713e96481.png)

