### PR TITLE
PYIC-1171 Add Provisioned Capacity Parameter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -12,9 +12,19 @@ Globals:
 Parameters:
   Environment:
     Type: String
+  ProvisionedConcurrentExecutions:
+    Type: Number
+    Description: >-
+      The number of lambda execution environments to keep permanently ready to reduce cold starts.
+    Default: 0
+
+Conditions:
+  AddProvisionedConcurrency: !Not
+    - !Equals
+      - !Ref ProvisionedConcurrentExecutions
+      -  0
 
 Resources:
-
   IPVCriUKPassportAPI:
     Type: AWS::Serverless::Api
     Properties:
@@ -103,6 +113,12 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /credentials/issue
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCriUKPassportIssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -156,6 +172,12 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /token
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCriUKPassportAccessTokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -226,6 +248,12 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /authorization
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCriUKPassportAuthorizationCodeFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -287,6 +315,12 @@ Resources:
             RestApiId: !Ref IPVCriUKPassportAPI
             Path: /jwt-authorization-request
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
This adds a parameter named `ProvisionedConcurrentExecutions` to the CFN
template. When this is set to a value greater than 0 each Passport Back
lambda will be provisioned that number of concurrent executions as a
means to reduce the impact of cold starts. The default value is 0.

This will permit turning on and adjusting provisioned concurrent
executions via CloudFormation update-stack operations.

In order to enable provisioned concurrent executions it is necessary to
also enable and create an alias which has been named 'live'.


### Why did it change
To help reduce the impact of cold starts for the MVP.

### Testing
This follows the same pattern as for core-back which was recently added. We do not have developer environments for passport CRI so it cannot be tested in the same way. The template validates and passes a CFN linter check. If this fails to apply it should be simple to revert.

### Issue tracking

- [PYI-1171](https://govukverify.atlassian.net/browse/PYI-1171)

