### PR TITLE
PYIC-1238: Return `aud` claim in VC JWT

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -111,6 +111,7 @@ public class DateStorePassportCheckIT {
                 passportCheckDao.getDcsPayload().toString(), result.getDcsPayload().toString());
         assertEquals(passportCheckDao.getEvidence().toString(), result.getEvidence().toString());
         assertEquals(passportCheckDao.getUserId(), result.getUserId());
+        assertEquals(passportCheckDao.getClientId(), result.getClientId());
     }
 
     private PassportCheckDao createPassportCheckDao() {
@@ -132,6 +133,7 @@ public class DateStorePassportCheckIT {
         Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 2, null);
         createdItemIds.add(resourceId);
 
-        return new PassportCheckDao(resourceId, dcsPayload, evidence, "test-user-id");
+        return new PassportCheckDao(
+                resourceId, dcsPayload, evidence, "test-user-id", "test-client-id");
     }
 }

--- a/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
+++ b/lambdas/authorizationcode/src/main/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandler.java
@@ -125,7 +125,8 @@ public class AuthorizationCodeHandler
                             UUID.randomUUID().toString(),
                             dcsPayload,
                             generateGpg45Score(unwrappedDcsResponse),
-                            userId);
+                            userId,
+                            authenticationRequest.getClientID().getValue());
             passportService.persistDcsResponse(passportCheckDao);
             AuthorizationCode authorizationCode =
                     authorizationCodeService.generateAuthorizationCode();

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -168,7 +168,7 @@ class AuthorizationCodeHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
         params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
+        params.put(OAuth2RequestParams.CLIENT_ID, "test-client-id");
         params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
         params.put(OAuth2RequestParams.SCOPE, "openid");
         event.setQueryStringParameters(params);
@@ -185,6 +185,7 @@ class AuthorizationCodeHandlerTest {
         ArgumentCaptor<PassportCheckDao> persistedDcsResponseItem =
                 ArgumentCaptor.forClass(PassportCheckDao.class);
         verify(passportService).persistDcsResponse(persistedDcsResponseItem.capture());
+        assertEquals("test-client-id", persistedDcsResponseItem.getValue().getClientId());
 
         verify(authorizationCodeService)
                 .persistAuthorizationCode(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -34,7 +34,8 @@ class VerifiableCredentialTest {
 
         Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 2, null);
         PassportCheckDao passportCheckDao =
-                new PassportCheckDao(RESOURCE_ID, dcsPayload, evidence, "test-user-id");
+                new PassportCheckDao(
+                        RESOURCE_ID, dcsPayload, evidence, "test-user-id", "test-client-id");
 
         VerifiableCredential verifiableCredential =
                 VerifiableCredential.fromPassportCheckDao(passportCheckDao);
@@ -116,7 +117,8 @@ class VerifiableCredentialTest {
                         PASSPORT_NUMBER, FAMILY_NAME, GIVEN_NAMES, DATE_OF_BIRTH, EXPIRY_DATE);
         Evidence evidence = new Evidence("b46cbad4-2680-433f-b12c-b09fc27f281f", 4, 2, null);
         PassportCheckDao passportCheckDao =
-                new PassportCheckDao(RESOURCE_ID, dcsPayload, evidence, "test-user-id");
+                new PassportCheckDao(
+                        RESOURCE_ID, dcsPayload, evidence, "test-user-id", "test-client-id");
 
         VerifiableCredential verifiableCredential =
                 VerifiableCredential.fromPassportCheckDao(passportCheckDao);
@@ -170,7 +172,8 @@ class VerifiableCredentialTest {
                         2,
                         List.of(ContraIndicators.D02));
         PassportCheckDao passportCheckDao =
-                new PassportCheckDao(RESOURCE_ID, dcsPayload, evidence, "test-user-id");
+                new PassportCheckDao(
+                        RESOURCE_ID, dcsPayload, evidence, "test-user-id", "test-client-id");
 
         VerifiableCredential verifiableCredential =
                 VerifiableCredential.fromPassportCheckDao(passportCheckDao);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -13,15 +13,21 @@ public class PassportCheckDao {
     private DcsPayload dcsPayload;
     private Evidence evidence;
     private String userId;
+    private String clientId;
 
     public PassportCheckDao() {}
 
     public PassportCheckDao(
-            String resourceId, DcsPayload dcsPayload, Evidence evidence, String userId) {
+            String resourceId,
+            DcsPayload dcsPayload,
+            Evidence evidence,
+            String userId,
+            String clientId) {
         this.resourceId = resourceId;
         this.dcsPayload = dcsPayload;
         this.evidence = evidence;
         this.userId = userId;
+        this.clientId = clientId;
     }
 
     @DynamoDbPartitionKey
@@ -55,5 +61,13 @@ public class PassportCheckDao {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckServiceTest.java
@@ -36,7 +36,11 @@ class DcsPassportCheckServiceTest {
     void shouldReturnCredentialsFromDataStore() {
         PassportCheckDao passportCheckDao =
                 new PassportCheckDao(
-                        UUID.randomUUID().toString(), dcsPayload, evidence, "test-user-id");
+                        UUID.randomUUID().toString(),
+                        dcsPayload,
+                        evidence,
+                        "test-user-id",
+                        "a-client-id");
 
         when(mockDataStore.getItem(anyString())).thenReturn(passportCheckDao);
 
@@ -46,5 +50,6 @@ class DcsPassportCheckServiceTest {
         assertEquals(passportCheckDao.getResourceId(), credential.getResourceId());
         assertEquals(passportCheckDao.getDcsPayload(), credential.getDcsPayload());
         assertEquals(passportCheckDao.getUserId(), credential.getUserId());
+        assertEquals(passportCheckDao.getClientId(), credential.getClientId());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -120,7 +120,8 @@ class PassportServiceTest {
                         LocalDate.now());
         Evidence evidence = new Evidence(UUID.randomUUID().toString(), 4, 4, null);
         PassportCheckDao dcsResponse =
-                new PassportCheckDao("UUID", dcsPayload, evidence, "test-user-id");
+                new PassportCheckDao(
+                        "UUID", dcsPayload, evidence, "test-user-id", "test-client-id");
         underTest.persistDcsResponse(dcsResponse);
         verify(dataStore).create(dcsResponse);
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return `aud` claim in VC JWT

### Why did it change

The core is now validating the claims set returned to it from a CRI.
This includes checking that the audience claim has the expected value.

This updates passport to return that claim with a value from the clients
configuration.

This is currently piggybacking on the clients issuer value from config.
At the moment these (issuer and audience) are the same with core. But we
need to look more closely at how we are managing these values as our
current approach is quite confusing.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1238](https://govukverify.atlassian.net/browse/PYI-1238)
