### PR TITLE
BAU: Fix KMS signature padding issue

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/KmsSigner.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/KmsSigner.java
@@ -17,7 +17,6 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.Set;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
@@ -26,7 +25,6 @@ public class KmsSigner implements JWSSigner {
 
     private final AWSKMS kmsClient;
 
-    private static final Base64.Encoder b64UrlEncoder = Base64.getUrlEncoder();
     private final JCAContext jcaContext = new JCAContext();
     private final String keyId;
 
@@ -60,7 +58,7 @@ public class KmsSigner implements JWSSigner {
 
         SignResult signResult = kmsClient.sign(signRequest);
 
-        return new Base64URL(b64UrlEncoder.encodeToString(signResult.getSignature().array()));
+        return Base64URL.encode(signResult.getSignature().array());
     }
 
     @Override


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix KMS signature padding issue

### Why did it change

Use nimbus's Base64URL.encode() function to base64URL encode the
signature bytes received from KMS.

The encoder offered by java.util via `Base64.getUrlEncoder()` does not
strip padding as we expected. It's java docs reference Table 2 of RFC
4648, which is a bit vague about the handling of padding (the "previous one"
the quote mentions is regular old base 64):

"This encoding is technically identical to the previous one, except
   for the 62:nd and 63:rd alphabet character, as indicated in Table 2."


As a result we were occasionally including an `=` on the end of our
serialized JWT strings. The nimbus lib is gracious enough to handle
these and still verify the signatures correctly, but it was causing
issues in SPOT. So here's a fix.
