### PR TITLE
BAU: Define common versions for libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,23 @@ spotless {
 		endWithNewline()
 	}
 }
+
+ext {
+	dependencyVersions = [
+		awsJavaSdkDynamodb:'1.12.146',
+		awsJavaSdkSqs:'1.12.197',
+		awsLambdaJavaCore:'1.2.1',
+		awsLambdaJavaEvents:'3.11.0',
+		dynamodbEnhanced:'2.17.116',
+		gson:'2.8.9',
+		jackson:'2.13.1',
+		nimbusJoseJwt:'9.16',
+		nimbusdsOauth2OidcSdk:'9.22.1',
+		powertoolsParameters:'1.9.0',
+		slf4j:'1.7.33'
+	]
+}
+
+subprojects {
+	task allDeps(type: DependencyReportTask) {}
+}

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -16,25 +16,25 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -14,25 +14,25 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0",
 			project(":lib").sourceSets.test.output
 }

--- a/lambdas/authorizationcode/build.gradle
+++ b/lambdas/authorizationcode/build.gradle
@@ -14,26 +14,26 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -14,26 +14,26 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0",
 			project(":lib").sourceSets.test.output
 }

--- a/lambdas/jwtauthorizationrequest/build.gradle
+++ b/lambdas/jwtauthorizationrequest/build.gradle
@@ -13,19 +13,19 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
-			"org.slf4j:slf4j-simple:1.7.32",
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			project(":lib")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
-			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
+	testImplementation "com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-inline:2.13.0",
+			"org.mockito:mockito-junit-jupiter:4.1.0",
 			project(":lib").sourceSets.test.output
 }
 

--- a/lambdas/stubdcs/build.gradle
+++ b/lambdas/stubdcs/build.gradle
@@ -14,25 +14,25 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,25 +13,25 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.146",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.22.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.1",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.1",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.1",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1",
-			"org.slf4j:slf4j-simple:1.7.33",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.116",
-			"software.amazon.lambda:powertools-parameters:1.9.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.16"
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters"
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.32.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.2.0",
 			"org.mockito:mockito-junit-jupiter:4.2.0",
-			"com.github.tomakehurst:wiremock-jre8:2.32.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.2.0"
 }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Define common versions for libs

### Why did it change

We were using different versions of the same libs in different lambdas.

This defines a structure in the root project where we can define the
versions we want to use and then pull them in in the sub projects.

This makes it easy to bump all versions in case of a security issue, as
well as ensuring consistency to help diagnose weird bugs.

This also sorts all the dependencies to scratch an itch.

