### PR TITLE
PYIC-1326 Update JwtAuthorizationRequest lambda to handle recoverable error scenario

### DIFF
--- a/lambdas/jwtauthorizationrequest/build.gradle
+++ b/lambdas/jwtauthorizationrequest/build.gradle
@@ -15,6 +15,10 @@ repositories {
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",

--- a/lambdas/jwtauthorizationrequest/src/main/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandler.java
+++ b/lambdas/jwtauthorizationrequest/src/main/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandler.java
@@ -88,7 +88,7 @@ public class JwtAuthorizationRequestHandler
                     new RedirectErrorResponse(
                             e.getRedirectUri(), e.getErrorObject().toJSONObject());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getErrorObject().getHTTPStatusCode(), errorResponse.toJSON());
+                    e.getErrorObject().getHTTPStatusCode(), errorResponse);
         } catch (JarValidationException e) {
             LOGGER.error("JAR validation failed: {}", e.getErrorObject().getDescription());
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
+++ b/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.KmsRsaDecrypter;
 import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
@@ -226,6 +227,27 @@ class JwtAuthorizationRequestHandlerTest {
         assertEquals(
                 OAuth2Error.INVALID_REQUEST_OBJECT.getDescription(),
                 errorResponse.getDescription());
+    }
+
+    @Test
+    void shouldReturn302WithRedirectUriWhenValidationFailsButIsRecoverable() throws Exception {
+        when(jarValidator.validateRequestJwt(any(), anyString()))
+                .thenThrow(
+                        new RecoverableJarValidationException(
+                                OAuth2Error.INVALID_REQUEST_OBJECT, "http://redirect-url.com"));
+
+        var event = new APIGatewayProxyRequestEvent();
+        Map<String, String> map = new HashMap<>();
+        map.put("client_id", "TEST");
+        event.setHeaders(map);
+        event.setBody(signedJWT.serialize());
+
+        var response = underTest.handleRequest(event, context);
+
+        assertEquals(302, response.getStatusCode());
+        assertEquals(
+                "\"{\\\"redirect_uri\\\":\\\"http://redirect-url.com\\\",\\\"oauth_error\\\":{\\\"error_description\\\":\\\"Invalid request JWT\\\",\\\"error\\\":\\\"invalid_request_object\\\"}}\"",
+                response.getBody());
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
+++ b/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java
@@ -246,7 +246,7 @@ class JwtAuthorizationRequestHandlerTest {
 
         assertEquals(302, response.getStatusCode());
         assertEquals(
-                "\"{\\\"redirect_uri\\\":\\\"http://redirect-url.com\\\",\\\"oauth_error\\\":{\\\"error_description\\\":\\\"Invalid request JWT\\\",\\\"error\\\":\\\"invalid_request_object\\\"}}\"",
+                "{\"redirect_uri\":\"http://redirect-url.com\",\"oauth_error\":{\"error_description\":\"Invalid request JWT\",\"error\":\"invalid_request_object\"}}",
                 response.getBody());
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.passport.library.error;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.minidev.json.JSONObject;
+
+public class RedirectErrorResponse {
+    private final String redirectUri;
+    private final JSONObject errorObject;
+
+    public RedirectErrorResponse(String redirectUri, JSONObject errorObject) {
+        this.redirectUri = redirectUri;
+        this.errorObject = errorObject;
+    }
+
+    @JsonProperty("redirect_uri")
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    @JsonProperty("oauth_error")
+    public JSONObject getErrorObject() {
+        return errorObject;
+    }
+
+    public String toJSON() {
+        try {
+            return new ObjectMapper().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.cri.passport.library.error;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import net.minidev.json.JSONObject;
 
 public class RedirectErrorResponse {
@@ -22,13 +20,5 @@ public class RedirectErrorResponse {
     @JsonProperty("oauth_error")
     public JSONObject getErrorObject() {
         return errorObject;
-    }
-
-    public String toJSON() {
-        try {
-            return new ObjectMapper().writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/RecoverableJarValidationException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/RecoverableJarValidationException.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.cri.passport.library.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class RecoverableJarValidationException extends JarValidationException {
+    private final String redirectUri;
+
+    public RecoverableJarValidationException(ErrorObject errorObject, String redirectUri) {
+        super(errorObject);
+        this.redirectUri = redirectUri;
+    }
+
+    public String getRedirectUri() {
+        return this.redirectUri;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -54,13 +54,13 @@ public class JarValidator {
 
     public JWTClaimsSet validateRequestJwt(SignedJWT signedJWT, String clientId)
             throws JarValidationException, ParseException {
-        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-        URI redirectUri = validateRedirectUri(claimsSet, clientId);
+        validateClientId(clientId);
         validateJWTHeader(signedJWT);
         validateSignature(signedJWT, clientId);
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+        URI redirectUri = validateRedirectUri(claimsSet, clientId);
 
         try {
-            validateClientId(clientId);
             JWTClaimsSet validatedClaimSet = getValidatedClaimSet(signedJWT, clientId);
             return validatedClaimSet;
         } catch (JarValidationException e) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
+import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.KmsRsaDecrypter;
@@ -52,14 +53,19 @@ public class JarValidator {
     }
 
     public JWTClaimsSet validateRequestJwt(SignedJWT signedJWT, String clientId)
-            throws JarValidationException {
-        validateClientId(clientId);
+            throws JarValidationException, ParseException {
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+        URI redirectUri = validateRedirectUri(claimsSet, clientId);
         validateJWTHeader(signedJWT);
         validateSignature(signedJWT, clientId);
-        JWTClaimsSet claimsSet = getValidatedClaimSet(signedJWT, clientId);
-        validateRedirectUri(claimsSet, clientId);
 
-        return claimsSet;
+        try {
+            validateClientId(clientId);
+            JWTClaimsSet validatedClaimSet = getValidatedClaimSet(signedJWT, clientId);
+            return validatedClaimSet;
+        } catch (JarValidationException e) {
+            throw new RecoverableJarValidationException(e.getErrorObject(), redirectUri.toString());
+        }
     }
 
     private void validateClientId(String clientId) throws JarValidationException {
@@ -159,7 +165,7 @@ public class JarValidator {
         }
     }
 
-    private void validateRedirectUri(JWTClaimsSet claimsSet, String clientId)
+    private URI validateRedirectUri(JWTClaimsSet claimsSet, String clientId)
             throws JarValidationException {
         try {
             URI redirectUri = claimsSet.getURIClaim(REDIRECT_URI_CLAIM);
@@ -174,6 +180,8 @@ public class JarValidator {
                         OAuth2Error.INVALID_GRANT.setDescription(
                                 "Invalid redirct_uri claim provided for configured client"));
             }
+
+            return redirectUri;
         } catch (ParseException e) {
             LOGGER.error(
                     "Failed to parse JWT claim set in order to access to the redirect_uri claim");


### PR DESCRIPTION
## Proposed changes

### What changed

For 'recoverable' JAR validation errors return the redirect_uri alongside the oauth error, in the shape:
```
{
    "redirect_uri": "http://example.com",
    "oauth_error": {
        "error": "server_error",
        "error_description": "Description of the oauth error"
    }
}
```

The error is considered recoverable as long as:
- client_id is valid
- redirect_uri is valid
- JAR decryption is valid
- JAR signature is valid

### Why did it change

If a JAR validation error occurs and is 'recoverable' we want to redirect the user back to core rather than ending the journey

### Issue tracking
- [PYIC-1326](https://govukverify.atlassian.net/browse/PYIC-1326)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed