### PR TITLE
BAU: Use SAM to create API key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -32,6 +32,8 @@ Resources:
       StageName: !Sub ${Environment}
       Auth:
         ApiKeyRequired: true
+        UsagePlan:
+          CreateUsagePlan: PER_API
       AccessLogSetting:
         DestinationArn: !GetAtt IPVCriUKPassportAPILogGroup.Arn
         Format: >-
@@ -398,26 +400,6 @@ Resources:
         - AttributeName: "authCode"
           KeyType: "HASH"
 
-  IpvCoreBackApiKey:
-    Type: AWS::ApiGateway::ApiKey
-    Properties:
-      Description: Api key for core back to authenticate against passport external Api
-      Enabled: true
-
-  IpvCriUkPassportBackApiUsagePlan:
-    Type: AWS::ApiGateway::UsagePlan
-    Properties:
-      ApiStages:
-        - ApiId: !Ref IPVCriUKPassportAPI
-          Stage: !Ref Environment
-
-  IpvCriUkPassportBackLinkUsagePlanCoreApiKey:
-    Type: AWS::ApiGateway::UsagePlanKey
-    Properties:
-      KeyId: !Ref IpvCoreBackApiKey
-      KeyType: API_KEY
-      UsagePlanId: !Ref IpvCriUkPassportBackApiUsagePlan
-              
   CRIPassportAccessTokensTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -442,4 +424,4 @@ Outputs:
   IpvCoreBackApiKeyId:
     Description: >
       The key id of the api key used by IPV Core to access passport back external api gateway
-    Value: !Ref IpvCoreBackApiKey
+    Value: !Ref IPVCriUKPassportAPIApiKey


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use SAM to create API key

### Why did it change

When trying to deploy the API gateway and the API usage plan at the same
time, cloudformation throws an error. The usage plan can't create as it
can't find the API stage. There is some suggestion in a GitHub issue on
the AWS SAM repo that there is a race condition:

https://github.com/aws/serverless-application-model/issues/1560

The suggested fix is to ensure that you're creating your usage plan with
SAM, rather than with cloudformation as we're currently doing. By
specifying the `UsagePlan` property of an `AWS::Serverless::Api` type,
SAM generates cloudformation resources for `AWS::ApiGateway::UsagePlan`,
`AWS::ApiGateway::ApiKey` and `AWS::ApiGateway::UsagePlanKey`. This
means we can remove them from the template. See the docs:

https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-api-apiusageplan.html

I'm guessing this change will change the API key currently being used,
so we will have to go unbreak some stuff.
