### PR TITLE
PYIC-1381: Add ttl value to passport dynamoDB items

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -48,6 +48,7 @@ jobs:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
           JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
           JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+          ENVIRONMENT: build
         run: ./gradlew intTest
 
       - name: SAM validate

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -55,6 +55,7 @@ jobs:
           DCS_RESPONSE_TABLE_NAME: dcs-response-build
           JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
           JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+          ENVIRONMENT: build
         run: ./gradlew intTest
 
       - name: Perform Static Analysis

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -130,6 +130,8 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
         - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/backendSessionTtl
+        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
@@ -203,6 +205,8 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
         - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/backendSessionTtl
+        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients/*
@@ -272,6 +276,8 @@ Resources:
             TableName: !Ref CRIPassportAuthCodesTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/backendSessionTtl
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -387,6 +393,9 @@ Resources:
       KeySchema:
         - AttributeName: "resourceId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
   CRIPassportAuthCodesTable:
     Type: AWS::DynamoDB::Table
@@ -399,6 +408,9 @@ Resources:
       KeySchema:
         - AttributeName: "authCode"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
   CRIPassportAccessTokensTable:
     Type: AWS::DynamoDB::Table
@@ -411,6 +423,9 @@ Resources:
       KeySchema:
         - AttributeName: "accessToken"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
 Outputs:
   IPVCriUkPassportAPIGatewayID:

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/DateStorePassportCheckIT.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -50,9 +51,14 @@ public class DateStorePassportCheckIT {
                     "The environment variable 'DCS_RESPONSE_TABLE_NAME' must be provided to run this test");
         }
 
+        ConfigurationService configurationService = new ConfigurationService();
+
         dcsResponseDataStore =
                 new DataStore<>(
-                        dcsResponseTableName, PassportCheckDao.class, DataStore.getClient(null));
+                        dcsResponseTableName,
+                        PassportCheckDao.class,
+                        DataStore.getClient(null),
+                        configurationService);
 
         AmazonDynamoDB independentClient =
                 AmazonDynamoDBClient.builder().withRegion("eu-west-2").build();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
@@ -2,11 +2,14 @@ package uk.gov.di.ipv.cri.passport.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @DynamoDbBean
-public class AccessTokenItem {
+@ExcludeFromGeneratedCoverageReport
+public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
     private String resourceId;
+    private long ttl;
 
     @DynamoDbPartitionKey
     public String getAccessToken() {
@@ -23,5 +26,13 @@ public class AccessTokenItem {
 
     public void setResourceId(String resourceId) {
         this.resourceId = resourceId;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
@@ -2,13 +2,16 @@ package uk.gov.di.ipv.cri.passport.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @DynamoDbBean
-public class AuthorizationCodeItem {
+@ExcludeFromGeneratedCoverageReport
+public class AuthorizationCodeItem implements DynamodbItem {
 
     private String authCode;
     private String resourceId;
     private String redirectUrl;
+    private long ttl;
 
     public AuthorizationCodeItem() {}
 
@@ -41,5 +44,13 @@ public class AuthorizationCodeItem {
 
     public void setRedirectUrl(String redirectUrl) {
         this.redirectUrl = redirectUrl;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/DynamodbItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/DynamodbItem.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.passport.library.persistence.item;
+
+public interface DynamodbItem {
+    void setTtl(long ttl);
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportCheckDao.java
@@ -8,12 +8,13 @@ import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
-public class PassportCheckDao {
+public class PassportCheckDao implements DynamodbItem {
     private String resourceId;
     private DcsPayload dcsPayload;
     private Evidence evidence;
     private String userId;
     private String clientId;
+    private long ttl;
 
     public PassportCheckDao() {}
 
@@ -69,5 +70,13 @@ public class PassportCheckDao {
 
     public void setClientId(String clientId) {
         this.clientId = clientId;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenService.java
@@ -28,7 +28,8 @@ public class AccessTokenService {
                         this.configurationService.getAccessTokensTableName(),
                         AccessTokenItem.class,
                         DataStore.getClient(
-                                this.configurationService.getDynamoDbEndpointOverride()));
+                                this.configurationService.getDynamoDbEndpointOverride()),
+                        this.configurationService);
     }
 
     public AccessTokenService(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
@@ -14,7 +14,8 @@ public class AuthorizationCodeService {
                 new DataStore<>(
                         configurationService.getAuthCodesTableName(),
                         AuthorizationCodeItem.class,
-                        DataStore.getClient(configurationService.getDynamoDbEndpointOverride()));
+                        DataStore.getClient(configurationService.getDynamoDbEndpointOverride()),
+                        configurationService);
     }
 
     public AuthorizationCodeService(DataStore<AuthorizationCodeItem> dataStore) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -248,4 +248,12 @@ public class ConfigurationService {
     public long maxJwtTtl() {
         return Long.parseLong(ssmProvider.get(System.getenv("MAX_JWT_TTL")));
     }
+
+    public long getBackendSessionTtl() {
+        return Long.parseLong(
+                ssmProvider.get(
+                        String.format(
+                                "/%s/credentialIssuers/ukPassport/self/backendSessionTtl",
+                                System.getenv("ENVIRONMENT"))));
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/DcsPassportCheckService.java
@@ -13,7 +13,8 @@ public class DcsPassportCheckService {
                 new DataStore<>(
                         configurationService.getDcsResponseTableName(),
                         PassportCheckDao.class,
-                        DataStore.getClient(configurationService.getDynamoDbEndpointOverride()));
+                        DataStore.getClient(configurationService.getDynamoDbEndpointOverride()),
+                        configurationService);
     }
 
     public DcsPassportCheckService(DataStore<PassportCheckDao> dataStore) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportService.java
@@ -48,7 +48,8 @@ public class PassportService {
                         this.configurationService.getDcsResponseTableName(),
                         PassportCheckDao.class,
                         DataStore.getClient(
-                                this.configurationService.getDynamoDbEndpointOverride()));
+                                this.configurationService.getDynamoDbEndpointOverride()),
+                        configurationService);
         this.httpClient = HttpClientSetUp.generateHttpClient(this.configurationService);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/persistance/DataStoreTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.AuthorizationCodeItem;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
 import java.util.stream.Stream;
 
@@ -34,6 +35,7 @@ class DataStoreTest {
     @Mock private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     @Mock private DynamoDbTable<AuthorizationCodeItem> mockDynamoDbTable;
     @Mock private PageIterable<AuthorizationCodeItem> mockPageIterable;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private AuthorizationCodeItem authorizationCodeItem;
     private DataStore<AuthorizationCodeItem> dataStore;
@@ -50,7 +52,10 @@ class DataStoreTest {
 
         dataStore =
                 new DataStore<>(
-                        TEST_TABLE_NAME, AuthorizationCodeItem.class, mockDynamoDbEnhancedClient);
+                        TEST_TABLE_NAME,
+                        AuthorizationCodeItem.class,
+                        mockDynamoDbEnhancedClient,
+                        mockConfigurationService);
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationServiceTest.java
@@ -110,4 +110,13 @@ class ConfigurationServiceTest {
         assertEquals(
                 "7JNbR3kjTHvbDkYt9F_RKwjmYgFaG3dORZqRmnMB-wY", underTest.getSha256Thumbprint());
     }
+
+    @Test
+    void shouldReturnBackendSessionTtl() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        long ttl = 7200;
+        when(ssmProvider.get("/test/credentialIssuers/ukPassport/self/backendSessionTtl"))
+                .thenReturn(String.valueOf(ttl));
+        assertEquals(ttl, configurationService.getBackendSessionTtl());
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Enabled the ttl setting on the DynamoDB tables.

Set the ttl property on each of the DynamoDB items based off a SSM param value. The value is recored as an epoch seconds value
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To ensure data is not retained for longer than necessary, the ttl value will be used by DynamoDB to automatically delete records after they have expired.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1381](https://govukverify.atlassian.net/browse/PYI-1381)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
