### PR TITLE
PYCI-1393: Remove token auth method configuration

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/KmsRsaDecrypterIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/cri/passport/integrationtest/KmsRsaDecrypterIT.java
@@ -42,7 +42,7 @@ class KmsRsaDecrypterIT {
         }
 
         String kmsId = configurationService.getJarKmsEncryptionKeyId();
-        String pubKey = configurationService.getJarKmsPublickKey();
+        String pubKey = configurationService.getJarKmsPublicKey();
 
         var header =
                 new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -62,7 +62,10 @@ public class AccessTokenHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            TokenRequest tokenRequest = createTokenRequest(input.getBody());
+            String requestBody = input.getBody();
+            tokenRequestValidator.authenticateClient(requestBody);
+
+            TokenRequest tokenRequest = createTokenRequest(requestBody);
 
             ValidationResult<ErrorObject> validationResult =
                     accessTokenService.validateTokenRequest(tokenRequest);
@@ -74,8 +77,6 @@ public class AccessTokenHandler
                         getHttpStatusCodeForErrorResponse(validationResult.getError()),
                         validationResult.getError().toJSONObject());
             }
-
-            tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeGrant authorizationCodeGrant =
                     (AuthorizationCodeGrant) tokenRequest.getAuthorizationGrant();
@@ -120,8 +121,8 @@ public class AccessTokenHandler
         } catch (ClientAuthenticationException e) {
             LOGGER.error("Client authentication failed: ", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
-                    OAuth2Error.INVALID_GRANT.toJSONObject());
+                    OAuth2Error.INVALID_CLIENT.getHTTPStatusCode(),
+                    OAuth2Error.INVALID_CLIENT.toJSONObject());
         }
     }
 

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -195,15 +195,12 @@ class AccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenClientAuthFails() throws Exception {
+    void shouldReturn401WhenClientAuthFails() throws Exception {
         String tokenRequestBody =
                 "code=12345&redirect_uri=http://test.com&grant_type=authorization_code&client_id=test_client_id";
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(tokenRequestBody);
-
-        when(mockAccessTokenService.validateTokenRequest(any()))
-                .thenReturn(ValidationResult.createValidResult());
 
         doThrow(new ClientAuthenticationException("error"))
                 .when(mockTokenRequestValidator)
@@ -211,9 +208,10 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
+
+        assertEquals(HTTPResponse.SC_UNAUTHORIZED, response.getStatusCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorResponse.getCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getDescription(), errorResponse.getDescription());
     }
 
     private ErrorObject createErrorObjectFromResponse(String responseBody) throws ParseException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -4,7 +4,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import uk.gov.di.ipv.cri.passport.library.domain.Thumbprints;
@@ -218,13 +217,6 @@ public class ConfigurationService {
         return getParameterFromStoreUsingEnv("PASSPORT_CRI_CLIENT_AUDIENCE");
     }
 
-    public String getClientAuthenticationMethod(String clientId) throws ParameterNotFoundException {
-        return ssmProvider.get(
-                String.format(
-                        "%s/%s/jwtAuthentication/authenticationMethod",
-                        System.getenv(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), clientId));
-    }
-
     public String getVerifiableCredentialIssuer() {
         return getParameterFromStoreUsingEnv("VERIFIABLE_CREDENTIAL_ISSUER_PARAM");
     }
@@ -241,7 +233,7 @@ public class ConfigurationService {
         return ssmProvider.get(System.getenv("JAR_ENCRYPTION_KEY_ID_PARAM"));
     }
 
-    public String getJarKmsPublickKey() {
+    public String getJarKmsPublicKey() {
         return ssmProvider.get(System.getenv("JAR_KMS_PUBLIC_KEY_PARAM"));
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -70,7 +70,7 @@ public class JarValidator {
 
     private void validateClientId(String clientId) throws JarValidationException {
         try {
-            configurationService.getClientAuthenticationMethod(clientId);
+            configurationService.getClientIssuer(clientId);
         } catch (ParameterNotFoundException e) {
             LOGGER.error("Unknown client id provided {}", clientId);
             throw new JarValidationException(

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -130,7 +130,7 @@ class JarValidatorTest {
     void shouldFailValidationChecksOnInvalidClientId()
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     ParseException {
-        when(configurationService.getClientAuthenticationMethod(anyString()))
+        when(configurationService.getClientIssuer(anyString()))
                 .thenThrow(ParameterNotFoundException.builder().build());
 
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove token auth method configuration

### Why did it change

Our OAuth spec states that a CRI should enforce the private_key_jwt
client authentication method. We currently have the ability to bypass
this with some config for client. We're using private keys for auth in
all envs and are well practiced at it. The configuration was originally
added to help us build out this feature. As we don't really need this
functionality anymore we should remove this potential foot cannon.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1393](https://govukverify.atlassian.net/browse/PYI-1393)

