### PR TITLE
PYIC-1421: Add condition for the logging subscription filters to not use them on the dev environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -31,6 +31,9 @@ Conditions:
       - !Equals [ !Ref Environment, "integration"]
       - !Equals [ !Ref Environment, "production"]
 
+  IsNotDevelopmentEnvironment: !Not
+    - Condition: IsDevelopmentEnvironment
+
 Resources:
   IPVCriUKPassportPrivateAPI:
     Type: AWS::Serverless::Api
@@ -55,7 +58,7 @@ Resources:
                 StringNotEquals:
                   'aws:SourceVpce': !If
                     - IsDevelopmentEnvironment
-                    - !ImportValue "network-shared-development-ApiGatewayVpcEndpointId"
+                    - !ImportValue "networking-shared-development-ApiGatewayVpcEndpointId"
                     - Fn::ImportValue:
                         !Sub "networking-${Environment}-ApiGatewayVpcEndpointId"
       StageName: !Sub ${Environment}
@@ -83,6 +86,7 @@ Resources:
 
   IPVCriUKPassportPrivateAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -121,6 +125,7 @@ Resources:
 
   IPVCriUKPassportAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -200,6 +205,7 @@ Resources:
 
   IPVCriUKPassportIssueCredentialFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -261,6 +267,7 @@ Resources:
 
   IPVCriUKPassportAccessTokenFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -339,6 +346,7 @@ Resources:
 
   IPVCriUKPassportAuthorizationCodeFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -416,6 +424,7 @@ Resources:
 
   IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new condition to toggle whether we need logging subscription filters depending on environment. For the development environment we don't need these subscription filters.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Remove the subscription filters for the development environment
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1421](https://govukverify.atlassian.net/browse/PYI-1421)

