### PR TITLE
BAU: Parse access token with non deprecated method

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -79,7 +80,7 @@ public class IssueCredentialHandler
                     RequestHelper.getHeaderByKey(input.getHeaders(), AUTHORIZATION_HEADER_KEY);
 
             // Performs validation on header value and throws a ParseException if invalid
-            AccessToken.parse(accessTokenString);
+            AccessToken.parse(accessTokenString, AccessTokenType.BEARER);
 
             String resourceId = accessTokenService.getResourceIdByAccessToken(accessTokenString);
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Parse access token with non deprecated method

### Why did it change

The method for parsing an access token with just the value is
deprecated. Instead, we can pass the expected token type. We're using
bearer tokens.
