### PR TITLE
PYIC-1447: Expire auth codes after a short period

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,6 +253,8 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/backendSessionTtl
         - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/authCodeExpirySeconds
+        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/clients/*

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -93,6 +93,16 @@ public class AccessTokenHandler
                         OAuth2Error.INVALID_GRANT.toJSONObject());
             }
 
+            if (authorizationCodeService.isExpired(authorizationCodeItem)) {
+                LOGGER.error(
+                        "Access Token could not be issued. The supplied authorization code has expired. Created at: {}",
+                        authorizationCodeItem.getCreationDateTime());
+                ErrorObject error =
+                        OAuth2Error.INVALID_GRANT.setDescription("Authorization code expired");
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        error.getHTTPStatusCode(), error.toJSONObject());
+            }
+
             if (redirectUrlsDoNotMatch(authorizationCodeItem, authorizationCodeGrant)) {
                 LOGGER.error(
                         "Redirect URL in token request does not match that received in auth code request. Resource ID: {}",

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
@@ -11,14 +11,17 @@ public class AuthorizationCodeItem implements DynamodbItem {
     private String authCode;
     private String resourceId;
     private String redirectUrl;
+    private String creationDateTime;
     private long ttl;
 
     public AuthorizationCodeItem() {}
 
-    public AuthorizationCodeItem(String authCode, String resourceId, String redirectUrl) {
+    public AuthorizationCodeItem(
+            String authCode, String resourceId, String redirectUrl, String creationDateTime) {
         this.authCode = authCode;
         this.resourceId = resourceId;
         this.redirectUrl = redirectUrl;
+        this.creationDateTime = creationDateTime;
     }
 
     @DynamoDbPartitionKey
@@ -52,5 +55,13 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public String getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(String creationDateTime) {
+        this.creationDateTime = creationDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -174,6 +174,14 @@ public class ConfigurationService {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
 
+    public long getAuthCodeExpirySeconds() {
+        return Long.parseLong(
+                ssmProvider.get(
+                        String.format(
+                                "/%s/credentialIssuers/ukPassport/self/authCodeExpirySeconds",
+                                System.getenv("ENVIRONMENT"))));
+    }
+
     public long getBearerAccessTokenTtl() {
         return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)


### PR DESCRIPTION
## Proposed changes

### What changed

Expire auth codes after a short period 

### Why did it change

We want to expire auth codes after a configured period of time. RFC 6749
states that they should have a short life span. 10 minutes is
recommended.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1447](https://govukverify.atlassian.net/browse/PYI-1447)
