### PR TITLE
BAU: Throw SsmException instead of ParameterNotFoundException

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -12,7 +12,7 @@ import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
@@ -71,7 +71,7 @@ public class JarValidator {
     private void validateClientId(String clientId) throws JarValidationException {
         try {
             configurationService.getClientIssuer(clientId);
-        } catch (ParameterNotFoundException e) {
+        } catch (SsmException e) {
             LOGGER.error("Unknown client id provided {}", clientId);
             throw new JarValidationException(
                     OAuth2Error.INVALID_CLIENT.setDescription("Unknown client id was provided"));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
@@ -129,7 +129,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException,
                     ParseException {
         when(configurationService.getClientIssuer(anyString()))
-                .thenThrow(ParameterNotFoundException.builder().build());
+                .thenThrow(SsmException.builder().build());
 
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Throw SsmException instead of ParameterNotFoundException

### Why did it change

We validate the client ID received in the auth request params by trying
to fetch some arbitrary config for that client from the param store. If
we are able to we consider the client ID validated.

If we don't have any configuration for that client ID the powertools lib
will throw. We were expecting to catch a ParameterNotFound exception,
however that's not what we get. Instead we get a SsmException due to the
lambda not having permissions to get that parameter (even though it
doesn't exist).

ParameterNotFoundException actually extends SsmException, so if for some
reason the lambda DID have perms and threw that specific exception we'd
still catch it here.
