### PR TITLE
PYIC-1449 Include state param in recoverable error response

### DIFF
--- a/lambdas/jwtauthorizationrequest/src/main/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandler.java
+++ b/lambdas/jwtauthorizationrequest/src/main/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandler.java
@@ -96,7 +96,7 @@ public class JwtAuthorizationRequestHandler
             LOGGER.error("JAR validation failed: {}", e.getErrorObject().getDescription());
             RedirectErrorResponse errorResponse =
                     new RedirectErrorResponse(
-                            e.getRedirectUri(), e.getErrorObject().toJSONObject());
+                            e.getRedirectUri(), e.getState(), e.getErrorObject().toJSONObject());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), errorResponse);
         } catch (JarValidationException e) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/RedirectErrorResponse.java
@@ -1,20 +1,29 @@
 package uk.gov.di.ipv.cri.passport.library.error;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import net.minidev.json.JSONObject;
 
 public class RedirectErrorResponse {
     private final String redirectUri;
+    private final String state;
     private final JSONObject errorObject;
 
-    public RedirectErrorResponse(String redirectUri, JSONObject errorObject) {
+    public RedirectErrorResponse(String redirectUri, String state, JSONObject errorObject) {
         this.redirectUri = redirectUri;
+        this.state = state;
         this.errorObject = errorObject;
     }
 
     @JsonProperty("redirect_uri")
     public String getRedirectUri() {
         return redirectUri;
+    }
+
+    @JsonProperty("state")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getState() {
+        return state;
     }
 
     @JsonProperty("oauth_error")

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/RecoverableJarValidationException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/RecoverableJarValidationException.java
@@ -6,13 +6,20 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 @ExcludeFromGeneratedCoverageReport
 public class RecoverableJarValidationException extends JarValidationException {
     private final String redirectUri;
+    private final String state;
 
-    public RecoverableJarValidationException(ErrorObject errorObject, String redirectUri) {
+    public RecoverableJarValidationException(
+            ErrorObject errorObject, String redirectUri, String state) {
         super(errorObject);
         this.redirectUri = redirectUri;
+        this.state = state;
     }
 
     public String getRedirectUri() {
         return this.redirectUri;
+    }
+
+    public String getState() {
+        return this.state;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -66,7 +66,9 @@ public class JarValidator {
             JWTClaimsSet validatedClaimSet = getValidatedClaimSet(signedJWT, clientId);
             return validatedClaimSet;
         } catch (JarValidationException e) {
-            throw new RecoverableJarValidationException(e.getErrorObject(), redirectUri.toString());
+            String state = claimsSet.getStringClaim("state");
+            throw new RecoverableJarValidationException(
+                    e.getErrorObject(), redirectUri.toString(), state);
         }
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidator.java
@@ -30,6 +30,7 @@ public class JarValidator {
     private static final Logger LOGGER = LoggerFactory.getLogger(JarValidator.class);
     private static final String REDIRECT_URI_CLAIM = "redirect_uri";
     public static final String CLIENT_ID = "client_id";
+    private static final String STATE = "state";
 
     private final KmsRsaDecrypter kmsRsaDecrypter;
     private final ConfigurationService configurationService;
@@ -66,7 +67,7 @@ public class JarValidator {
             JWTClaimsSet validatedClaimSet = getValidatedClaimSet(signedJWT, clientId);
             return validatedClaimSet;
         } catch (JarValidationException e) {
-            String state = claimsSet.getStringClaim("state");
+            String state = claimsSet.getStringClaim(STATE);
             throw new RecoverableJarValidationException(
                     e.getErrorObject(), redirectUri.toString(), state);
         }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/validation/JarValidatorTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -237,6 +238,7 @@ class JarValidatorTest {
                 "JWT missing required claims: [exp, iat, iss, nbf, response_type, sub]",
                 errorObject.getDescription());
         assertEquals(redirectUriClaim, thrown.getRedirectUri());
+        assertNull(thrown.getState());
     }
 
     @Test
@@ -286,6 +288,7 @@ class JarValidatorTest {
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
         assertEquals("JWT audience rejected: [invalid-audience]", errorObject.getDescription());
         assertEquals(redirectUriClaim, thrown.getRedirectUri());
+        assertEquals(stateClaim, thrown.getState());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

When it is present and parsable in the request, include the `state` param in the JwtAuthorizationRequest recoverable error response:
```
{
   redirect_uri: 'redirect.com',
   state: 'xyz',
   oauth_error: {
      error: 'invalid_request',
      error_description: 'something went wrong'
   }
}
```
We omit it from the response if it's not present in the request

### Why did it change

RFC6749 (https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1) requires the state param to be included in the redirect uri query alongside the error params (if it is provided in the original client authorization request). We pass it back to the frontend here so it can set it in the redirect url.

### Issue tracking
- [PYIC-1449](https://govukverify.atlassian.net/browse/PYIC-1449)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
