### PR TITLE
PYIC-1487: Log in JSON format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,11 @@ ext {
 		awsJavaSdkSqs:'1.12.197',
 		awsLambdaJavaCore:'1.2.1',
 		awsLambdaJavaEvents:'3.11.0',
+		awsLambdaJavaLog4j2:'1.5.1',
 		dynamodbEnhanced:'2.17.116',
 		gson:'2.8.9',
 		jackson:'2.13.1',
+		log4j:'2.17.1',
 		nimbusJoseJwt:'9.16',
 		nimbusdsOauth2OidcSdk:'9.22.1',
 		powertoolsParameters:'1.9.0',
@@ -51,5 +53,21 @@ ext {
 }
 
 subprojects {
+
+	configurations {
+		loggingImplementation
+		loggingRunTimeOnly
+	}
+
+	dependencies {
+		loggingImplementation "org.slf4j:slf4j-api:$dependencyVersions.slf4j"
+
+		loggingRunTimeOnly "org.apache.logging.log4j:log4j-api:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-core:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-layout-template-json:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-slf4j18-impl:$dependencyVersions.log4j",
+				"com.amazonaws:aws-lambda-java-log4j2:$dependencyVersions.awsLambdaJavaLog4j2"
+	}
+
 	task allDeps(type: DependencyReportTask) {}
 }

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -24,10 +24,12 @@ dependencies {
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/accesstoken/src/main/resources/log4j2.yaml
+++ b/lambdas/accesstoken/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/authorizationcode/build.gradle
+++ b/lambdas/authorizationcode/build.gradle
@@ -25,10 +25,12 @@ dependencies {
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/authorizationcode/src/main/resources/log4j2.yaml
+++ b/lambdas/authorizationcode/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -25,10 +25,12 @@ dependencies {
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/issuecredential/src/main/resources/log4j2.yaml
+++ b/lambdas/issuecredential/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/jwtauthorizationrequest/build.gradle
+++ b/lambdas/jwtauthorizationrequest/build.gradle
@@ -22,8 +22,10 @@ dependencies {
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	testImplementation "com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
 			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",

--- a/lambdas/jwtauthorizationrequest/src/main/resources/log4j2.yaml
+++ b/lambdas/jwtauthorizationrequest/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters"
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Log in JSON format

### Why did it change

This leverages the AWS docs found here:
https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html#java-logging-log4j2
as well as RFC0030:
https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0030-cross-programme-logging-format.md
and the auth teams previous good work:
https://github.com/alphagov/di-authentication-api/blob/main/ipv-api/src/main/resources/log4j2.xml

This uses the aws-lambda-java-log4j2 library to allow is to include
the AWS request ID in each log line.

It defines a couple of new gradle configurations in the root project
which are then pulled in by the sub projects to reduce repetition.

It adds a YAML configuration file to each sub project to configure the
logging. Currently we're only adding a couple of custom fields,
session-id and aws-request-id. We can add more as we identify what they
are. The log4j2 docs are good for understanding what's happening:
https://logging.apache.org/log4j/2.x/manual/configuration.html#YAML
https://logging.apache.org/log4j/2.x/manual/json-template-layout.html

As we're already using slf4j to create our loggers we don't need to
update our code o get hold of a logger which is nice.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1487](https://govukverify.atlassian.net/browse/PYI-1487)
