### PR TITLE
PYIC-1495 Set Provisioned Concurrency Within Template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -11,17 +11,31 @@ Globals:
 
 Parameters:
   Environment:
+    AllowedValues:
+      - development
+      - build
+      - staging
+      - integration
+      - production
     Type: String
-  ProvisionedConcurrentExecutions:
-    Type: Number
-    Description: >-
-      The number of lambda execution environments to keep permanently ready to reduce cold starts.
-    Default: 0
+
+Mappings:
+  EnvironmentConfiguration:
+    development:
+      provisionedConcurrency: 0
+    build:
+      provisionedConcurrency: 0
+    staging:
+      provisionedConcurrency: 1
+    integration:
+      provisionedConcurrency: 1
+    production:
+      provisionedConcurrency: 1
 
 Conditions:
   AddProvisionedConcurrency: !Not
     - !Equals
-      - !Ref ProvisionedConcurrentExecutions
+      - !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
       -  0
 
   IsDevelopmentEnvironment: !Not
@@ -202,7 +216,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCriUKPassportIssueCredentialFunctionLogGroup:
@@ -269,7 +283,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCriUKPassportAccessTokenFunctionLogGroup:
@@ -351,7 +365,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCriUKPassportAuthorizationCodeFunctionLogGroup:
@@ -432,7 +446,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCriUKPassportJwTAuthorizationRequestFunctionLogGroup:


### PR DESCRIPTION
This sets the provisioned concurrency of each lambda based using a look
up in the Mappings section. This makes it simpler to find the setting
and to deploy changes.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The initial implementation relied upon setting the parameter via the cli or CI configuration. Having the setting within the CI configuration makes it harder to find and also creates "interesting" scenarios where updates to the CI configuration do not necessarily trigger a deployment of the app that propagates through environments. Moving the setting into the template's Mappings section makes it simpler to find and will always trigger a deployment when it changes.

This has been successfully deployed into my dev environment. Integration and Production are currently set to provisioned concurrency of 1 and this brings staging inline with production as best practice.

Concourse pipeline configuration is not currently passing the parameter when deploying the stack so it is safe to remove in this commit.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1495](https://govukverify.atlassian.net/browse/PYIC-1495)

