### PR TITLE
PYIC-1448: Revoke access token if auth code is re-used

### DIFF
--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -1,11 +1,11 @@
 version = 0.1
 
 
-[dev.deploy.parameters]
-stack_name = "ipv-cri-uk-passport-back-development"
-s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
-s3_prefix = "ipv-cri-uk-passport-back-development"
+[development.deploy.parameters]
+stack_name = "ipv-passport-back-development"
+s3_bucket = "di-ipv-cri-lambda-artifact-bucket"
+s3_prefix = "passport-back-development"
 region = "eu-west-2"
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "Environment=\"dev\""
+parameter_overrides = "Environment=\"development\""
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -499,9 +499,18 @@ Resources:
       AttributeDefinitions:
         - AttributeName: "accessToken"
           AttributeType: "S"
+        - AttributeName: "authCode"
+          AttributeType: "S"
       KeySchema:
         - AttributeName: "accessToken"
           KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "authorizationCode-index"
+          KeySchema:
+            - AttributeName: "authCode"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
       TimeToLiveSpecification:
         AttributeName: "ttl"
         Enabled: true

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/DataStore.java
@@ -1,14 +1,18 @@
 package uk.gov.di.ipv.cri.passport.library.persistence;
 
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.DynamodbItem;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
@@ -60,6 +64,19 @@ public class DataStore<T extends DynamodbItem> {
 
     public T getItem(String partitionValue) {
         return getItemByKey(Key.builder().partitionValue(partitionValue).build());
+    }
+
+    public List<T> getItemByIndex(String indexName, String value) throws DynamoDbException {
+        DynamoDbIndex<T> index = getTable().index(indexName);
+        var attVal = AttributeValue.builder().s(value).build();
+        var queryConditional =
+                QueryConditional.keyEqualTo(Key.builder().partitionValue(attVal).build());
+        var queryEnhancedRequest =
+                QueryEnhancedRequest.builder().queryConditional(queryConditional).build();
+
+        return index.query(queryEnhancedRequest).stream()
+                .flatMap(page -> page.items().stream())
+                .collect(Collectors.toList());
     }
 
     public List<T> getItems(String partitionValue) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.passport.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @DynamoDbBean
@@ -9,6 +10,7 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
     private String resourceId;
+    private String authCode;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -26,6 +28,15 @@ public class AccessTokenItem implements DynamodbItem {
 
     public void setResourceId(String resourceId) {
         this.resourceId = resourceId;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "authorizationCode-index")
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
     }
 
     public long getTtl() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
@@ -12,16 +12,22 @@ public class AuthorizationCodeItem implements DynamodbItem {
     private String resourceId;
     private String redirectUrl;
     private String creationDateTime;
+    private String exchangeDateTime;
     private long ttl;
 
     public AuthorizationCodeItem() {}
 
     public AuthorizationCodeItem(
-            String authCode, String resourceId, String redirectUrl, String creationDateTime) {
+            String authCode,
+            String resourceId,
+            String redirectUrl,
+            String creationDateTime,
+            String exchangeDateTime) {
         this.authCode = authCode;
         this.resourceId = resourceId;
         this.redirectUrl = redirectUrl;
         this.creationDateTime = creationDateTime;
+        this.exchangeDateTime = exchangeDateTime;
     }
 
     @DynamoDbPartitionKey
@@ -63,5 +69,13 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public void setCreationDateTime(String creationDateTime) {
         this.creationDateTime = creationDateTime;
+    }
+
+    public String getExchangeDateTime() {
+        return exchangeDateTime;
+    }
+
+    public void setExchangeDateTime(String exchangeDateTime) {
+        this.exchangeDateTime = exchangeDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
@@ -44,11 +44,19 @@ public class AuthorizationCodeService {
                         DigestUtils.sha256Hex(authorizationCode),
                         resourceId,
                         redirectUrl,
-                        Instant.now().toString()));
+                        Instant.now().toString(),
+                        null));
     }
 
     public void revokeAuthorizationCode(String authorizationCode) {
         dataStore.delete(DigestUtils.sha256Hex(authorizationCode));
+    }
+
+    public void setExchangeDateTime(String authorizationCode) {
+        AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
+        authorizationCodeItem.setExchangeDateTime(Instant.now().toString());
+
+        dataStore.update(authorizationCodeItem);
     }
 
     public boolean isExpired(AuthorizationCodeItem authCodeItem) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/util/ListUtil.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/util/ListUtil.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.cri.passport.library.util;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ListUtil {
+    public static <T> T getOneItemOrThrowError(List<T> list) throws IllegalArgumentException {
+        if (Objects.isNull(list) || list.isEmpty()) {
+            throw new IllegalArgumentException("No items found");
+        } else if (list.size() > 1) {
+            throw new IllegalArgumentException("More than one item found");
+        } else {
+            return list.get(0);
+        }
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeServiceTest.java
@@ -88,12 +88,24 @@ class AuthorizationCodeServiceTest {
     }
 
     @Test
-    void shouldCallDeleteWithAuthCode() {
+    void shouldCallUpdateWithExchangeDateTimeValue() {
         AuthorizationCode testCode = new AuthorizationCode();
+        AuthorizationCodeItem authorizationCodeItem =
+                new AuthorizationCodeItem(
+                        testCode.getValue(),
+                        "test-resource",
+                        "http://example.com",
+                        Instant.now().toString(),
+                        null);
 
-        authorizationCodeService.revokeAuthorizationCode(testCode.getValue());
+        when(mockDataStore.getItem(testCode.getValue())).thenReturn(authorizationCodeItem);
+        authorizationCodeService.setExchangeDateTime(testCode.getValue());
 
-        verify(mockDataStore).delete(DigestUtils.sha256Hex(testCode.getValue()));
+        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
+                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
+        verify(mockDataStore).update(authorizationCodeItemArgumentCaptor.capture());
+
+        assertNotNull(authorizationCodeItemArgumentCaptor.getValue().getExchangeDateTime());
     }
 
     @Test
@@ -104,7 +116,8 @@ class AuthorizationCodeServiceTest {
                         "auth-code",
                         "resource-id",
                         "redirect-url",
-                        Instant.now().minusSeconds(601).toString());
+                        Instant.now().minusSeconds(601).toString(),
+                        null);
 
         assertTrue(authorizationCodeService.isExpired(expiredAuthCodeItem));
     }
@@ -117,7 +130,8 @@ class AuthorizationCodeServiceTest {
                         "auth-code",
                         "resource-id",
                         "redirect-url",
-                        Instant.now().minusSeconds(599).toString());
+                        Instant.now().minusSeconds(599).toString(),
+                        null);
 
         assertFalse(authorizationCodeService.isExpired(expiredAuthCodeItem));
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/utils/ListUtilsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/utils/ListUtilsTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.ipv.cri.passport.library.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.passport.library.util.ListUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ListUtilsTest {
+
+    @Test
+    void shouldReturnItemFromList() {
+        List<String> testList = Collections.singletonList("test");
+
+        String result = ListUtil.getOneItemOrThrowError(testList);
+
+        assertEquals("test", result);
+    }
+
+    @Test
+    void shouldThrowExceptionIfListIsNull() {
+        try {
+            ListUtil.getOneItemOrThrowError(null);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("No items found", e.getMessage());
+        }
+    }
+
+    @Test
+    void shouldThrowExceptionIfListIsEmpty() {
+        try {
+            ListUtil.getOneItemOrThrowError(Collections.emptyList());
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("No items found", e.getMessage());
+        }
+    }
+
+    @Test
+    void shouldThrowExceptionIfMoreThanOneItemInList() {
+        try {
+            List<String> testList = Arrays.asList("test", "test2", "test3");
+            ListUtil.getOneItemOrThrowError(testList);
+
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("More than one item found", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Revoke issued access token if an auth code is re-used. 

Updated the auth codes to not delete straight after being used, but instead be marked with a exchangeDateTime field. The issued access tokens also have the original auth code number that they were issued from stored against them as a secondary index within DynamoDB. If an auth code is re-used then the access token that was issued is revoked.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To update our OAUTH security to match with the expected standards defined in the RFC
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1448](https://govukverify.atlassian.net/browse/PYI-1448)
