### PR TITLE
PYIC-1488: Add identifiers to JSON logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,28 +47,11 @@ ext {
 		log4j:'2.17.1',
 		nimbusJoseJwt:'9.16',
 		nimbusdsOauth2OidcSdk:'9.22.1',
-		powertoolsParameters:'1.9.0',
-		slf4j:'1.7.33'
+		powertoolsLogging:'1.12.2',
+		powertoolsParameters:'1.9.0'
 	]
 }
 
 subprojects {
-
-	configurations {
-		loggingImplementation
-		loggingRunTimeOnly
-	}
-
-	dependencies {
-		loggingImplementation "org.slf4j:slf4j-api:$rootProject.ext.dependencyVersions.slf4j"
-
-		loggingRunTimeOnly "org.apache.logging.log4j:log4j-api:$rootProject.ext.dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-core:$rootProject.ext.dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-layout-template-json:$rootProject.ext.dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-slf4j18-impl:$rootProject.ext.dependencyVersions.log4j",
-				"com.amazonaws:aws-lambda-java-log4j2:$rootProject.ext.dependencyVersions.awsLambdaJavaLog4j2",
-				"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson"
-	}
-
 	task allDeps(type: DependencyReportTask) {}
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -26,7 +26,8 @@ dependencies {
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"org.apache.logging.log4j:log4j-api:$rootProject.ext.dependencyVersions.log4j",
+			"org.apache.logging.log4j:log4j-core:$rootProject.ext.dependencyVersions.log4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 repositories {
@@ -26,10 +27,9 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
-			configurations.loggingImplementation,
 			project(":lib")
 
-	runtimeOnly configurations.loggingRunTimeOnly
+	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/validation/TokenRequestValidator.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.accesstoken.domain.ConfigurationServicePublicKeySelector;
 import uk.gov.di.ipv.cri.passport.accesstoken.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
+import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 
@@ -41,6 +42,7 @@ public class TokenRequestValidator {
             clientJwt = PrivateKeyJWT.parse(requestBody);
             verifier.verify(clientJwtWithConcatSignature(clientJwt, requestBody), null, null);
             validateMaxAllowedAuthClientTtl(clientJwt.getJWTAuthenticationClaimsSet());
+            LogHelper.attachClientIdToLogs(clientJwt.getClientID().getValue());
         } catch (ParseException
                 | InvalidClientException
                 | JOSEException

--- a/lambdas/accesstoken/src/main/resources/log4j2.yaml
+++ b/lambdas/accesstoken/src/main/resources/log4j2.yaml
@@ -1,20 +1,20 @@
 Configuration:
   status: warn
   appenders:
-    Lambda:
-      name: Lambda
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
       JsonTemplateLayout:
-        eventTemplateUri: "classpath:JsonLayout.json"
-        eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
-            format: JSON
-            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
   Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
     Root:
       level: info
       AppenderRef:
-        ref: Lambda
-
+        ref: JsonAppender
 

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -50,7 +50,8 @@ class AccessTokenHandlerTest {
                     new AuthorizationCode().toString(),
                     UUID.randomUUID().toString(),
                     "http://example.com",
-                    Instant.now().toString());
+                    Instant.now().toString(),
+                    UUID.randomUUID().toString());
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     @Mock private Context context;
@@ -241,7 +242,8 @@ class AccessTokenHandlerTest {
                         new AuthorizationCode().toString(),
                         UUID.randomUUID().toString(),
                         "http://example.com",
-                        Instant.now().toString());
+                        Instant.now().toString(),
+                        UUID.randomUUID().toString());
 
         authorizationCodeItem.setIssuedAccessToken("test-access-token");
         authorizationCodeItem.setExchangeDateTime(Instant.now().toString());
@@ -275,7 +277,8 @@ class AccessTokenHandlerTest {
                         new AuthorizationCode().toString(),
                         UUID.randomUUID().toString(),
                         "http://example.com",
-                        Instant.now().toString());
+                        Instant.now().toString(),
+                        UUID.randomUUID().toString());
 
         authorizationCodeItem.setIssuedAccessToken("test-access-token");
         authorizationCodeItem.setExchangeDateTime(Instant.now().toString());

--- a/lambdas/authorizationcode/build.gradle
+++ b/lambdas/authorizationcode/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 repositories {
@@ -27,10 +28,9 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
-			configurations.loggingImplementation,
 			project(":lib")
 
-	runtimeOnly configurations.loggingRunTimeOnly
+	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/authorizationcode/src/main/resources/log4j2.yaml
+++ b/lambdas/authorizationcode/src/main/resources/log4j2.yaml
@@ -1,20 +1,20 @@
 Configuration:
   status: warn
   appenders:
-    Lambda:
-      name: Lambda
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
       JsonTemplateLayout:
-        eventTemplateUri: "classpath:JsonLayout.json"
-        eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
-            format: JSON
-            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
   Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
     Root:
       level: info
       AppenderRef:
-        ref: Lambda
-
+        ref: JsonAppender
 

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 repositories {
@@ -27,10 +28,9 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
-			configurations.loggingImplementation,
 			project(":lib")
 
-	runtimeOnly configurations.loggingRunTimeOnly
+	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -14,8 +14,8 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
@@ -31,6 +31,7 @@ import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 import uk.gov.di.ipv.cri.passport.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.passport.library.helpers.JwtHelper;
 import uk.gov.di.ipv.cri.passport.library.helpers.KmsSigner;
+import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -47,7 +48,7 @@ import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Ver
 public class IssueCredentialHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(IssueCredentialHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
     private final DcsPassportCheckService dcsPassportCheckService;
@@ -83,6 +84,7 @@ public class IssueCredentialHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachComponentIdToLogs();
         try {
             AccessToken accessToken =
                     AccessToken.parse(
@@ -129,6 +131,7 @@ public class IssueCredentialHandler
 
             PassportCheckDao passportCheck =
                     dcsPassportCheckService.getDcsPassportCheck(accessTokenItem.getResourceId());
+            LogHelper.attachClientIdToLogs(passportCheck.getClientId());
 
             VerifiableCredential verifiableCredential =
                     VerifiableCredential.fromPassportCheckDao(passportCheck);

--- a/lambdas/issuecredential/src/main/resources/log4j2.yaml
+++ b/lambdas/issuecredential/src/main/resources/log4j2.yaml
@@ -1,20 +1,20 @@
 Configuration:
   status: warn
   appenders:
-    Lambda:
-      name: Lambda
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
       JsonTemplateLayout:
-        eventTemplateUri: "classpath:JsonLayout.json"
-        eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
-            format: JSON
-            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
   Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
     Root:
       level: info
       AppenderRef:
-        ref: Lambda
-
+        ref: JsonAppender
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -125,14 +125,15 @@ class IssueCredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn200OnSuccessfulDcsCredentialRequest()
-            throws SqsException, JsonProcessingException {
+    void shouldReturn200OnSuccessfulDcsCredentialRequest() throws SqsException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken.getValue());
-        accessTokenItem.setResourceId(TEST_RESOURCE_ID);
-        accessTokenItem.setAccessTokenExpiryDateTime(Instant.now().plusSeconds(3600).toString());
+        AccessTokenItem accessTokenItem =
+                new AccessTokenItem(
+                        accessToken.getValue(),
+                        TEST_RESOURCE_ID,
+                        Instant.now().plusSeconds(3600).toString(),
+                        UUID.randomUUID().toString());
         Map<String, String> headers =
                 Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
         event.setHeaders(headers);
@@ -162,10 +163,12 @@ class IssueCredentialHandlerTest {
             throws JsonProcessingException, ParseException, JOSEException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken.getValue());
-        accessTokenItem.setAccessTokenExpiryDateTime(Instant.now().plusSeconds(3600).toString());
-        accessTokenItem.setResourceId(TEST_RESOURCE_ID);
+        AccessTokenItem accessTokenItem =
+                new AccessTokenItem(
+                        accessToken.getValue(),
+                        TEST_RESOURCE_ID,
+                        Instant.now().plusSeconds(3600).toString(),
+                        UUID.randomUUID().toString());
         Map<String, String> headers =
                 Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
         event.setHeaders(headers);
@@ -349,9 +352,12 @@ class IssueCredentialHandlerTest {
         event.setHeaders(headers);
         setRequestBodyAsPlainJWT(event);
 
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken.toAuthorizationHeader());
-        accessTokenItem.setAccessTokenExpiryDateTime(Instant.now().plusSeconds(60).toString());
+        AccessTokenItem accessTokenItem =
+                new AccessTokenItem(
+                        accessToken.getValue(),
+                        TEST_RESOURCE_ID,
+                        Instant.now().plusSeconds(60).toString(),
+                        UUID.randomUUID().toString());
         accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
 
         when(mockAccessTokenService.getAccessTokenItem(accessToken.getValue()))
@@ -375,10 +381,12 @@ class IssueCredentialHandlerTest {
     void shouldReturnErrorResponseWhenExpiredAccessTokenProvided() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken.getValue());
-        accessTokenItem.setResourceId(TEST_RESOURCE_ID);
-        accessTokenItem.setAccessTokenExpiryDateTime(Instant.now().minusSeconds(5).toString());
+        AccessTokenItem accessTokenItem =
+                new AccessTokenItem(
+                        accessToken.getValue(),
+                        TEST_RESOURCE_ID,
+                        Instant.now().minusSeconds(5).toString(),
+                        UUID.randomUUID().toString());
         Map<String, String> headers =
                 Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
         event.setHeaders(headers);

--- a/lambdas/jwtauthorizationrequest/build.gradle
+++ b/lambdas/jwtauthorizationrequest/build.gradle
@@ -6,6 +6,7 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 repositories {
@@ -22,10 +23,9 @@ dependencies {
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			configurations.loggingImplementation,
 			project(":lib")
 
-	runtimeOnly configurations.loggingRunTimeOnly
+	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
 
 	testImplementation "com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
 			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",

--- a/lambdas/jwtauthorizationrequest/src/main/resources/log4j2.yaml
+++ b/lambdas/jwtauthorizationrequest/src/main/resources/log4j2.yaml
@@ -1,20 +1,20 @@
 Configuration:
   status: warn
   appenders:
-    Lambda:
-      name: Lambda
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
       JsonTemplateLayout:
-        eventTemplateUri: "classpath:JsonLayout.json"
-        eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
-            format: JSON
-            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
   Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
     Root:
       level: info
       AppenderRef:
-        ref: Lambda
-
+        ref: JsonAppender
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.32.0",

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -16,15 +16,13 @@ public enum ErrorResponse {
     MISSING_SHARED_ATTRIBUTES_JWT(1007, "Missing shared attributes JWT from request body"),
     FAILED_TO_PARSE(1008, "Failed to parse"),
     MISSING_CLIENT_ID_QUERY_PARAMETER(1009, "Missing client_id query parameter"),
-    FAILED_TO_VERIFY_SIGNATURE(1010, "Failed to verify the signature of the JWT"),
-    JWT_SIGNATURE_IS_INVALID(1011, "Signature of the shared attribute JWT is invalid"),
     INVALID_REDIRECT_URL(1012, "Provided redirect URL is not in those configured for client"),
     UNKNOWN_CLIENT_ID(1013, "Unknown client id provided in request params"),
     INVALID_REQUEST_PARAM(1014, "Invalid request param"),
-    SHARED_CLAIM_IS_MISSING(1015, "shared_claim missing from shared attribute JWT"),
     FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE(
             1016, "Failed to send message to aws SQS audit event queue"),
-    MISSING_USER_ID_HEADER(1017, "Missing user_id header in authorisation request");
+    MISSING_USER_ID_HEADER(1017, "Missing user_id header in authorisation request"),
+    MISSING_PASSPORT_SESSION_ID_HEADER(1018, "Missing passport_session_id header");
 
     private final int code;
     private final String message;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/HttpResponseExceptionWithErrorBody.java
@@ -2,8 +2,6 @@ package uk.gov.di.ipv.cri.passport.library.exceptions;
 
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 
-import java.util.Map;
-
 public class HttpResponseExceptionWithErrorBody extends Exception {
     private final int statusCode;
     private final ErrorResponse errorResponse;
@@ -21,7 +19,7 @@ public class HttpResponseExceptionWithErrorBody extends Exception {
         return this.statusCode;
     }
 
-    public Map<String, Object> getErrorBody() {
-        return Map.of("code", errorResponse.getCode(), "message", errorResponse.getMessage());
+    public ErrorResponse getErrorResponse() {
+        return this.errorResponse;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/OAuthHttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/exceptions/OAuthHttpResponseExceptionWithErrorBody.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.cri.passport.library.exceptions;
+
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+
+@ExcludeFromGeneratedCoverageReport
+public class OAuthHttpResponseExceptionWithErrorBody extends HttpResponseExceptionWithErrorBody {
+    public OAuthHttpResponseExceptionWithErrorBody(int statusCode, ErrorResponse errorResponse) {
+        super(statusCode, errorResponse);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.cri.passport.library.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class LogHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private LogHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static final String CLIENT_ID_LOG_FIELD = "client-id";
+    public static final String SESSION_ID_LOG_FIELD = "session-id";
+    public static final String COMPONENT_ID_LOG_FIELD = "component-id";
+    public static final String COMPONENT_ID = "passport-cri";
+
+    public static void attachComponentIdToLogs() {
+        attachFieldToLogs(COMPONENT_ID_LOG_FIELD, COMPONENT_ID);
+    }
+
+    public static void attachClientIdToLogs(String clientId) {
+        attachFieldToLogs(CLIENT_ID_LOG_FIELD, clientId);
+    }
+
+    public static void attachSessionIdToLogs(String sessionId) {
+        attachFieldToLogs(SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    private static void attachFieldToLogs(String field, String value) {
+        LoggingUtils.appendKey(field, value);
+        LOGGER.info("{} attached to logs", field);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
@@ -11,7 +11,19 @@ public class AccessTokenItem implements DynamodbItem {
     private String accessTokenExpiryDateTime;
     private String resourceId;
     private String revokedAtDateTime;
+    private String passportSessionId;
     private long ttl;
+
+    public AccessTokenItem(
+            String accessToken,
+            String resourceId,
+            String accessTokenExpiryDateTime,
+            String passportSessionId) {
+        this.accessToken = accessToken;
+        this.resourceId = resourceId;
+        this.accessTokenExpiryDateTime = accessTokenExpiryDateTime;
+        this.passportSessionId = passportSessionId;
+    }
 
     @DynamoDbPartitionKey
     public String getAccessToken() {
@@ -52,5 +64,13 @@ public class AccessTokenItem implements DynamodbItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public String getPassportSessionId() {
+        return passportSessionId;
+    }
+
+    public void setPassportSessionId(String passportSessionId) {
+        this.passportSessionId = passportSessionId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
@@ -14,16 +14,22 @@ public class AuthorizationCodeItem implements DynamodbItem {
     private String creationDateTime;
     private String issuedAccessToken;
     private String exchangeDateTime;
+    private String passportSessionId;
     private long ttl;
 
     public AuthorizationCodeItem() {}
 
     public AuthorizationCodeItem(
-            String authCode, String resourceId, String redirectUrl, String creationDateTime) {
+            String authCode,
+            String resourceId,
+            String redirectUrl,
+            String creationDateTime,
+            String passportSessionId) {
         this.authCode = authCode;
         this.resourceId = resourceId;
         this.redirectUrl = redirectUrl;
         this.creationDateTime = creationDateTime;
+        this.passportSessionId = passportSessionId;
     }
 
     @DynamoDbPartitionKey
@@ -81,5 +87,13 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public void setExchangeDateTime(String exchangeDateTime) {
         this.exchangeDateTime = exchangeDateTime;
+    }
+
+    public String getPassportSessionId() {
+        return passportSessionId;
+    }
+
+    public void setPassportSessionId(String passportSessionId) {
+        this.passportSessionId = passportSessionId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
@@ -38,13 +38,17 @@ public class AuthorizationCodeService {
     }
 
     public void persistAuthorizationCode(
-            String authorizationCode, String resourceId, String redirectUrl) {
+            String authorizationCode,
+            String resourceId,
+            String redirectUrl,
+            String passportSessionId) {
         dataStore.create(
                 new AuthorizationCodeItem(
                         DigestUtils.sha256Hex(authorizationCode),
                         resourceId,
                         redirectUrl,
-                        Instant.now().toString()));
+                        Instant.now().toString(),
+                        passportSessionId));
     }
 
     public void setIssuedAccessToken(String authorizationCode, String accessToken) {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelperTest.java
@@ -1,11 +1,15 @@
 package uk.gov.di.ipv.cri.passport.library.helpers;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RequestHelperTest {
 
@@ -22,5 +26,27 @@ class RequestHelperTest {
     @Test
     void getHeaderByKeyShouldReturnNullIfNoHeadersProvided() {
         assertNull(RequestHelper.getHeaderByKey(null, "ohdearohdear"));
+    }
+
+    @Test
+    void getPassportSessionIdShouldReturnSessionIdFromHeaders() throws Exception {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("passport_session_id", "qwertyuiop"));
+
+        assertEquals("qwertyuiop", RequestHelper.getPassportSessionId(event));
+    }
+
+    @Test
+    void getPassportSessionIdShouldThrowIfSessionIdNotFound() throws Exception {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("passport_session_id", ""));
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getPassportSessionId(event));
+
+        assertEquals(
+                ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER, exception.getErrorResponse());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add identifiers to JSON logs
See this required PR on passport-front: https://github.com/alphagov/di-ipv-cri-uk-passport-front/pull/164

### Why did it change

This updates each lambda to add the passport session ID, the client ID
and a component ID to the logs as soon as they're available.

The component ID is a constant thing we add to help with filtering logs.
The same value will be added in the frontend logs. I've intentionally
left it environment agnostic (so not a URL) so it's easy to handle
across all deployments.

The logging makes use of the AWS Powertools logging lib. This has
simplified our dependencies, and adds some extra fields to our logs for
free. It also handles clean up of the MDC for us.

Instantiation of the loggers no longer uses slf4j. We're not going to
be changing the logging framework anytime soon and it makes things a
little simpler.

This change has also altered the responses of some of the lambdas in
some situations. Rather than returning a journey error response, I've
changed it to just returning a 400. This happens where we the
ipv-session-id has not been sent in the header. If this ever happens
something is seriously wrong and trying to continue the journey is
probably a bad idea and we should just throw. Opinions encouraged.

The passport CRI works differently than the core in that we don't have a
user state table with a unique identifier. Instead, the users state is
managed in the frontend app. As such a bit more work has had to be done
to have a common identifier that we can log across the lambdas.

The two lambdas called by the frontend app are now expecting to receive
a session ID in the headers. There is a PR for the frontend app to
start supplying this. This session ID is then persisted via the auth
code and access token tables so it can be retrieved and logged in the
access token and resource endpoints. Using the session ID from the
frontend app will also help link the lambda invocations to logs from the
frontends.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1488](https://govukverify.atlassian.net/browse/PYI-1488)

