### PR TITLE
BAU: Fix JSON logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,13 +60,14 @@ subprojects {
 	}
 
 	dependencies {
-		loggingImplementation "org.slf4j:slf4j-api:$dependencyVersions.slf4j"
+		loggingImplementation "org.slf4j:slf4j-api:$rootProject.ext.dependencyVersions.slf4j"
 
-		loggingRunTimeOnly "org.apache.logging.log4j:log4j-api:$dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-core:$dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-layout-template-json:$dependencyVersions.log4j",
-				"org.apache.logging.log4j:log4j-slf4j18-impl:$dependencyVersions.log4j",
-				"com.amazonaws:aws-lambda-java-log4j2:$dependencyVersions.awsLambdaJavaLog4j2"
+		loggingRunTimeOnly "org.apache.logging.log4j:log4j-api:$rootProject.ext.dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-core:$rootProject.ext.dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-layout-template-json:$rootProject.ext.dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-slf4j18-impl:$rootProject.ext.dependencyVersions.log4j",
+				"com.amazonaws:aws-lambda-java-log4j2:$rootProject.ext.dependencyVersions.awsLambdaJavaLog4j2",
+				"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson"
 	}
 
 	task allDeps(type: DependencyReportTask) {}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix JSON logging

### Why did it change

The logging was broken with the move to using log4j2 for logging in JSON
format. This was due to a missing dependency that allows parsing of YAML
files. log4j2 was failing to parse the YAML configuration file and
falling back to its default configuration. The default config only logs
warn and above.

The general approach to logging my change fairly soon, but we should fix this
up in the mean time none the less.