### PR TITLE
PYIC-1462 Validate access token expiry

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCovera
 @ExcludeFromGeneratedCoverageReport
 public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
+    private String accessTokenExpiryDateTime;
     private String resourceId;
     private String revokedAtDateTime;
     private long ttl;
@@ -19,6 +20,14 @@ public class AccessTokenItem implements DynamodbItem {
 
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
+    }
+
+    public String getAccessTokenExpiryDateTime() {
+        return accessTokenExpiryDateTime;
+    }
+
+    public void setAccessTokenExpiryDateTime(String accessTokenExpiryDateTime) {
+        this.accessTokenExpiryDateTime = accessTokenExpiryDateTime;
     }
 
     public String getResourceId() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -32,7 +32,7 @@ public class ConfigurationService {
 
     public static final int LOCALHOST_PORT = 4567;
     private static final String LOCALHOST_URI = "http://localhost:" + LOCALHOST_PORT;
-    private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
+    private static final long DEFAULT_ACCESS_TOKEN_EXPIRY_SECONDS = 3600L;
     private static final String IS_LOCAL = "IS_LOCAL";
     private static final String CLIENT_REDIRECT_URL_SEPARATOR = ",";
     public static final String CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX =
@@ -182,10 +182,10 @@ public class ConfigurationService {
                                 System.getenv("ENVIRONMENT"))));
     }
 
-    public long getBearerAccessTokenTtl() {
+    public long getAccessTokenExpirySeconds() {
         return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)
-                .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
+                .orElse(DEFAULT_ACCESS_TOKEN_EXPIRY_SECONDS);
     }
 
     public URI getDynamoDbEndpointOverride() {


### PR DESCRIPTION
## Proposed changes

### What changed

Store access token expiry time on dynamodb record so we can check it on issuing credential. Throw access denied error if access token has expired.

### Why did it change

[RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-7) states that the resource server must validate any access token to ensure it hasn't expired. We weren't checking this previously.

### Issue tracking
- [PYIC-1462](https://govukverify.atlassian.net/browse/PYIC-1462)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
