### PR TITLE
PYIC-1514: Add Passport PII to REQUEST_SENT audit event

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -332,6 +332,7 @@ Resources:
           DCS_TLS_ROOT_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/tlsRootCertificate"
           DCS_TLS_INTERMEDIATE_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/tlsIntermediateCertificate"
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
+          VERIFIABLE_CREDENTIAL_ISSUER_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialIssuer"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBCrudPolicy:

--- a/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
+++ b/lambdas/authorizationcode/src/test/java/uk/gov/di/ipv/cri/passport/authorizationcode/AuthorizationCodeHandlerTest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.authorizationcode.validation.AuthRequestValidator;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsResponse;
@@ -52,6 +53,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -146,8 +148,16 @@ class AuthorizationCodeHandlerTest {
 
         var response = underTest.handleRequest(event, context);
 
-        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT);
-        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_RESPONSE_RECEIVED);
+        ArgumentCaptor<AuditEvent> argumentCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(auditService, times(2)).sendAuditEvent(argumentCaptor.capture());
+        List<AuditEvent> capturedValues = argumentCaptor.getAllValues();
+        assertEquals(
+                AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT,
+                capturedValues.get(0).getEventName());
+        assertEquals(
+                AuditEventTypes.IPV_PASSPORT_CRI_RESPONSE_RECEIVED,
+                capturedValues.get(1).getEventName());
+
         verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -17,7 +17,14 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditExtensions;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditExtensionsVcEvidence;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditRestricted;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditRestrictedVcCredentialSubject;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.CredentialSubject;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredential;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
@@ -118,7 +125,7 @@ public class IssueCredentialHandler
             SignedJWT signedJWT =
                     generateAndSignVerifiableCredentialJwt(verifiableCredential, passportCheck);
 
-            auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_VC_ISSUED);
+            auditService.sendAuditEvent(createAuditEvent(verifiableCredential, passportCheck));
 
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatus.SC_OK, signedJWT.serialize());
@@ -139,6 +146,22 @@ public class IssueCredentialHandler
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE);
         }
+    }
+
+    private AuditEvent createAuditEvent(VerifiableCredential vc, PassportCheckDao passportCheck) {
+        CredentialSubject credentialSubject = vc.getCredentialSubject();
+        String componentId = configurationService.getVerifiableCredentialIssuer();
+        AuditEventTypes eventType = AuditEventTypes.IPV_PASSPORT_CRI_VC_ISSUED;
+        AuditEventUser user = new AuditEventUser(passportCheck.getUserId(), null);
+        AuditRestricted restricted =
+                new AuditRestrictedVcCredentialSubject(
+                        credentialSubject.getName(),
+                        credentialSubject.getBirthDate(),
+                        credentialSubject.getPassport());
+        AuditExtensions extensions =
+                new AuditExtensionsVcEvidence(
+                        configurationService.getVerifiableCredentialIssuer(), vc.getEvidence());
+        return new AuditEvent(eventType, componentId, user, restricted, extensions);
     }
 
     private SignedJWT generateAndSignVerifiableCredentialJwt(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -23,8 +23,10 @@ import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
@@ -123,7 +125,8 @@ class IssueCredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn200OnSuccessfulDcsCredentialRequest() throws SqsException {
+    void shouldReturn200OnSuccessfulDcsCredentialRequest()
+            throws SqsException, JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         Map<String, String> headers =
@@ -143,7 +146,11 @@ class IssueCredentialHandlerTest {
         APIGatewayProxyResponseEvent response =
                 issueCredentialHandler.handleRequest(event, mockContext);
 
-        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_VC_ISSUED);
+        ArgumentCaptor<AuditEvent> argumentCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(mockAuditService).sendAuditEvent(argumentCaptor.capture());
+        assertEquals(
+                AuditEventTypes.IPV_PASSPORT_CRI_VC_ISSUED,
+                argumentCaptor.getValue().getEventName());
 
         assertEquals(200, response.getStatusCode());
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
@@ -4,26 +4,58 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.time.Instant;
+
 @ExcludeFromGeneratedCoverageReport
 public class AuditEvent {
-    @JsonProperty private int timestamp;
+    @JsonProperty private final long timestamp;
 
     @JsonProperty("event_name")
-    private AuditEventTypes event;
+    private final AuditEventTypes eventName;
+
+    @JsonProperty("component_id")
+    private final String componentId;
+
+    @JsonProperty private final AuditEventUser user;
+    @JsonProperty private final AuditRestricted restricted;
+    @JsonProperty private final AuditExtensions extensions;
 
     @JsonCreator
     public AuditEvent(
-            @JsonProperty(value = "timestamp", required = true) int timestamp,
-            @JsonProperty(value = "event_name", required = true) AuditEventTypes event) {
-        this.timestamp = timestamp;
-        this.event = event;
+            @JsonProperty(value = "event_name", required = true) AuditEventTypes eventName,
+            @JsonProperty(value = "component_id", required = false) String componentId,
+            @JsonProperty(value = "user", required = false) AuditEventUser user,
+            @JsonProperty(value = "restricted", required = false) AuditRestricted restricted,
+            @JsonProperty(value = "extensions", required = false) AuditExtensions extensions) {
+        this.timestamp = Instant.now().getEpochSecond();
+        this.eventName = eventName;
+        this.componentId = componentId;
+        this.user = user;
+        this.restricted = restricted;
+        this.extensions = extensions;
     }
 
     public long getTimestamp() {
         return timestamp;
     }
 
-    public AuditEventTypes getEvent() {
-        return event;
+    public AuditEventTypes getEventName() {
+        return eventName;
+    }
+
+    public String getComponentId() {
+        return componentId;
+    }
+
+    public AuditEventUser getUser() {
+        return user;
+    }
+
+    public AuditRestricted getRestricted() {
+        return restricted;
+    }
+
+    public AuditExtensions getExtensions() {
+        return extensions;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventUser.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventUser.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class AuditEventUser {
+
+    @JsonProperty(value = "user_id")
+    private final String userId;
+
+    @JsonProperty(value = "session_id")
+    private final String sessionId;
+
+    public AuditEventUser(
+            @JsonProperty(value = "user_id", required = false) String userId,
+            @JsonProperty(value = "session_id", required = false) String sessionId) {
+        this.userId = userId;
+        this.sessionId = sessionId;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditExtensions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditExtensions.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+public interface AuditExtensions {}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditExtensionsVcEvidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditExtensionsVcEvidence.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
+
+import java.util.List;
+
+public class AuditExtensionsVcEvidence implements AuditExtensions {
+    @JsonProperty("iss")
+    private final String iss;
+
+    @JsonProperty("evidence")
+    private final List<Evidence> evidence;
+
+    public AuditExtensionsVcEvidence(
+            @JsonProperty(value = "iss", required = false) String iss,
+            @JsonProperty(value = "evidence", required = false) List<Evidence> evidence) {
+        this.iss = iss;
+        this.evidence = evidence;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditRestricted.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditRestricted.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+public interface AuditRestricted {}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditRestrictedVcCredentialSubject.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditRestrictedVcCredentialSubject.java
@@ -1,0 +1,40 @@
+package uk.gov.di.ipv.cri.passport.library.auditing;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.BirthDate;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Name;
+import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Passport;
+
+import java.util.List;
+
+public class AuditRestrictedVcCredentialSubject implements AuditRestricted {
+
+    private final List<Name> name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private final List<BirthDate> birthDate;
+
+    private final List<Passport> passport;
+
+    public AuditRestrictedVcCredentialSubject(
+            @JsonProperty(value = "name", required = true) List<Name> name,
+            @JsonProperty(value = "birthDate", required = true) List<BirthDate> birthDate,
+            @JsonProperty(value = "passport", required = true) List<Passport> passport) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.passport = passport;
+    }
+
+    public List<Name> getName() {
+        return name;
+    }
+
+    public List<BirthDate> getBirthDate() {
+        return birthDate;
+    }
+
+    public List<Passport> getPassport() {
+        return passport;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
@@ -9,11 +9,11 @@ import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 
-import java.time.Instant;
-
 public class AuditService {
     private final AmazonSQS sqs;
     private final String queueUrl;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public AuditService(AmazonSQS sqs, ConfigurationService configurationService) {
         this.sqs = sqs;
@@ -25,22 +25,19 @@ public class AuditService {
     }
 
     public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {
+        sendAuditEvent(new AuditEvent(eventType, null, null, null, null));
+    }
+
+    public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {
         try {
             SendMessageRequest sendMessageRequest =
                     new SendMessageRequest()
                             .withQueueUrl(queueUrl)
-                            .withMessageBody(generateMessageBody(eventType));
+                            .withMessageBody(objectMapper.writeValueAsString(auditEvent));
 
             sqs.sendMessage(sendMessageRequest);
         } catch (JsonProcessingException e) {
             throw new SqsException(e);
         }
-    }
-
-    private String generateMessageBody(AuditEventTypes eventType) throws JsonProcessingException {
-        AuditEvent auditEvent = new AuditEvent((int) Instant.now().getEpochSecond(), eventType);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.writeValueAsString(auditEvent);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.passport.library.service;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 
@@ -46,9 +46,10 @@ class AuditServiceTest {
         assertEquals(
                 "https://example-queue-url", sqsSendMessageRequestCaptor.getValue().getQueueUrl());
 
-        AuditEvent messageBody =
-                objectMapper.readValue(
-                        sqsSendMessageRequestCaptor.getValue().getMessageBody(), AuditEvent.class);
-        assertEquals(AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT, messageBody.getEvent());
+        JsonNode messageBody =
+                objectMapper.readTree(sqsSendMessageRequestCaptor.getValue().getMessageBody());
+        assertEquals(
+                AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT.name(),
+                messageBody.get("event_name").asText());
     }
 }


### PR DESCRIPTION

## Proposed changes

### What changed

Add details of the request sent to DCS in the IPV_PASSPORT_CRI_REQUEST_SENT. This is in the same format as VC `credential_subject` field.

Also add VC details to the IPV_PASSPORT_CRI_VC_ISSUED audit event.

This is a minimal implementation to meet our deadline and should be revised with additional testing and code refactoring.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We need to log this information for fraud detection purposes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1514](https://govukverify.atlassian.net/browse/PYI-1514)
