### PR TITLE
PYIC-1468: revoke access tokens after use

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -141,6 +141,8 @@ public class IssueCredentialHandler
             SignedJWT signedJWT =
                     generateAndSignVerifiableCredentialJwt(verifiableCredential, passportCheck);
 
+            accessTokenService.revokeAccessToken(accessTokenItem.getAccessToken());
+
             auditService.sendAuditEvent(createAuditEvent(verifiableCredential, passportCheck));
 
             return ApiGatewayResponseGenerator.proxyJwtResponse(
@@ -161,6 +163,11 @@ public class IssueCredentialHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE);
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Failed to revoke access token after use becasuse: {}", e.getMessage());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_REVOKE_ACCESS_TOKEN);
         }
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -131,6 +131,8 @@ public class IssueCredentialHandler
                                 .toJSONObject());
             }
 
+            accessTokenService.revokeAccessToken(accessTokenItem.getAccessToken());
+
             PassportCheckDao passportCheck =
                     dcsPassportCheckService.getDcsPassportCheck(accessTokenItem.getResourceId());
             LogHelper.attachClientIdToLogs(passportCheck.getClientId());
@@ -140,8 +142,6 @@ public class IssueCredentialHandler
 
             SignedJWT signedJWT =
                     generateAndSignVerifiableCredentialJwt(verifiableCredential, passportCheck);
-
-            accessTokenService.revokeAccessToken(accessTokenItem.getAccessToken());
 
             auditService.sendAuditEvent(createAuditEvent(verifiableCredential, passportCheck));
 
@@ -164,7 +164,7 @@ public class IssueCredentialHandler
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE);
         } catch (IllegalArgumentException e) {
-            LOGGER.error("Failed to revoke access token after use becasuse: {}", e.getMessage());
+            LOGGER.error("Failed to revoke access token after use because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_REVOKE_ACCESS_TOKEN);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NamePartType;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.NameParts;
 import uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredential;
+import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
@@ -61,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
@@ -190,6 +192,8 @@ class IssueCredentialHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals(6, claimsSet.size());
         assertEquals("https://example.com/issuer", claimsSet.get("aud").asText());
+
+        verify(mockAccessTokenService).revokeAccessToken(accessTokenItem.getAccessToken());
 
         JsonNode vcNode = claimsSet.get("vc");
         VerifiableCredential verifiableCredential =
@@ -407,6 +411,41 @@ class IssueCredentialHandlerTest {
                         .appendDescription(" - The supplied access token has expired")
                         .getDescription(),
                 responseBody.get("error_description"));
+    }
+
+    void shouldReturnErrorResponseWhenAccessTokenCannotBeRevoked() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        Map<String, String> headers =
+                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+        event.setHeaders(headers);
+
+        AccessTokenItem accessTokenItem = new AccessTokenItem();
+        accessTokenItem.setResourceId(TEST_RESOURCE_ID);
+        accessTokenItem.setAccessToken(accessToken.toAuthorizationHeader());
+
+        when(mockAccessTokenService.getAccessTokenItem(anyString())).thenReturn(accessTokenItem);
+        when(mockDcsPassportCheckService.getDcsPassportCheck(anyString()))
+                .thenReturn(passportCheckDao);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn("test-issuer");
+        when(mockConfigurationService.getClientIssuer(clientId))
+                .thenReturn("https://example.com/issuer");
+
+        doThrow(new IllegalArgumentException("Test error"))
+                .when(mockAccessTokenService)
+                .revokeAccessToken(anyString());
+
+        APIGatewayProxyResponseEvent response =
+                issueCredentialHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(500, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_REVOKE_ACCESS_TOKEN.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_REVOKE_ACCESS_TOKEN.getMessage(),
+                responseBody.get("message"));
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/error/ErrorResponse.java
@@ -22,7 +22,8 @@ public enum ErrorResponse {
     FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE(
             1016, "Failed to send message to aws SQS audit event queue"),
     MISSING_USER_ID_HEADER(1017, "Missing user_id header in authorisation request"),
-    MISSING_PASSPORT_SESSION_ID_HEADER(1018, "Missing passport_session_id header");
+    MISSING_PASSPORT_SESSION_ID_HEADER(1018, "Missing passport_session_id header"),
+    FAILED_TO_REVOKE_ACCESS_TOKEN(1019, "Failed to revoke access token");
 
     private final int code;
     private final String message;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Revoke the access token after it has been used to retrieve a credential
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To avoid any possible re-use of access tokens.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1468](https://govukverify.atlassian.net/browse/PYI-1468)

