### PR TITLE
BAU: Give AccessTokenItem default constructor

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AccessTokenItem.java
@@ -14,6 +14,9 @@ public class AccessTokenItem implements DynamodbItem {
     private String passportSessionId;
     private long ttl;
 
+    // required for DynamoDb BeanTableSchema
+    public AccessTokenItem() {}
+
     public AccessTokenItem(
             String accessToken,
             String resourceId,


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give AccessTokenItem default constructor

### Why did it change

DynamodDb BeanTableSchema needs a default constructor. A specific
constructor was defined which meant the default no longer existed. This
puts it back.

Have tested by deploying to the dev account and all good.
