### PR TITLE
BAU: Update log field names

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -96,7 +96,7 @@ public class AccessTokenHandler
                         OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
                         OAuth2Error.INVALID_GRANT.toJSONObject());
             }
-            LogHelper.attachSessionIdToLogs(authorizationCodeItem.getPassportSessionId());
+            LogHelper.attachPassportSessionIdToLogs(authorizationCodeItem.getPassportSessionId());
 
             if (authorizationCodeItem.getIssuedAccessToken() != null) {
                 LOGGER.error(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
@@ -13,9 +13,9 @@ public class LogHelper {
         throw new IllegalStateException("Utility class");
     }
 
-    public static final String CLIENT_ID_LOG_FIELD = "client-id";
-    public static final String SESSION_ID_LOG_FIELD = "session-id";
-    public static final String COMPONENT_ID_LOG_FIELD = "component-id";
+    public static final String CLIENT_ID_LOG_FIELD = "clientId";
+    public static final String PASSPORT_SESSION_ID_LOG_FIELD = "passportSessionId";
+    public static final String COMPONENT_ID_LOG_FIELD = "componentId";
     public static final String COMPONENT_ID = "passport-cri";
 
     public static void attachComponentIdToLogs() {
@@ -26,8 +26,8 @@ public class LogHelper {
         attachFieldToLogs(CLIENT_ID_LOG_FIELD, clientId);
     }
 
-    public static void attachSessionIdToLogs(String sessionId) {
-        attachFieldToLogs(SESSION_ID_LOG_FIELD, sessionId);
+    public static void attachPassportSessionIdToLogs(String sessionId) {
+        attachFieldToLogs(PASSPORT_SESSION_ID_LOG_FIELD, sessionId);
     }
 
     private static void attachFieldToLogs(String field, String value) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/RequestHelper.java
@@ -60,7 +60,7 @@ public class RequestHelper {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER);
         }
-        LogHelper.attachSessionIdToLogs(ipvSessionId);
+        LogHelper.attachPassportSessionIdToLogs(ipvSessionId);
         return ipvSessionId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenService.java
@@ -60,7 +60,7 @@ public class AccessTokenService {
     public AccessTokenItem getAccessTokenItem(String accessToken) {
         AccessTokenItem accessTokenItem = dataStore.getItem(DigestUtils.sha256Hex(accessToken));
         if (accessTokenItem != null) {
-            LogHelper.attachSessionIdToLogs(accessTokenItem.getPassportSessionId());
+            LogHelper.attachPassportSessionIdToLogs(accessTokenItem.getPassportSessionId());
         }
         return accessTokenItem;
     }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update log field names

### Why did it change

Make the log field names camel case to be consistent with what we log in
core. This also changes the session_id field to passportSessionId. This
is to help to differentiate it from other session IDs we may end up
logging, such as persistent session ID. It's also consistent with what
we're logging in core. This will also get logged in the passport front
so we can tie frontend and backend logs together.

