### PR TITLE
PYIC-1529: Return correct error code if redirect URLs don't match

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -117,8 +117,8 @@ public class AccessTokenHandler
                         "Redirect URL in token request does not match that received in auth code request. Resource ID: {}",
                         authorizationCodeItem.getResourceId());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        OAuth2Error.INVALID_REQUEST.getHTTPStatusCode(),
-                        OAuth2Error.INVALID_REQUEST.toJSONObject());
+                        OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
+                        OAuth2Error.INVALID_GRANT.toJSONObject());
             }
 
             AccessTokenResponse accessTokenResponse =

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -206,8 +206,8 @@ class AccessTokenHandlerTest {
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(OAuth2Error.INVALID_REQUEST.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_REQUEST.getDescription(), errorResponse.getDescription());
+        assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
+        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
     }
 
     @Test


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return correct error code if redirect URLs don't match

### Why did it change

If the redirect URL received at the token endpoint doesn't match that
received on the auth endpoint we should return invalid_grant, according
to the OAuth spec.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1529](https://govukverify.atlassian.net/browse/PYI-1529)
