### PR TITLE
PYIC-1450 Validate JTI of access token private key JWT request

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -256,6 +256,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           CRI_PASSPORT_AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAuthCodesTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
+          CRI_PASSPORT_CLIENT_AUTH_JWT_IDS_TABLE_NAME: !Ref CRIPassportClientAuthJwtIdsTable
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"
           PASSPORT_CRI_CLIENT_AUTH_MAX_TTL: !Sub "/${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl"
           PASSPORT_CRI_CLIENT_AUDIENCE: !Sub "/${Environment}/credentialIssuers/ukPassport/self/audienceForClients"
@@ -264,6 +265,8 @@ Resources:
             TableName: !Ref CRIPassportAuthCodesTable
         - DynamoDBCrudPolicy:
             TableName: !Ref CRIPassportAccessTokensTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CRIPassportClientAuthJwtIdsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/audienceForClients
         - SSMParameterReadPolicy:
@@ -524,6 +527,26 @@ Resources:
           AttributeType: "S"
       KeySchema:
         - AttributeName: "accessToken"
+          KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
+      SSESpecification:
+        # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
+        SSEEnabled: true
+        SSEType: KMS
+
+  CRIPassportClientAuthJwtIdsTable:
+    Type: AWS::DynamoDB::Table
+    # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
+    Properties:
+      TableName: !Sub "cri-passport-client-auth-jwt-ids-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "jwtId"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "jwtId"
           KeyType: "HASH"
       TimeToLiveSpecification:
         AttributeName: "ttl"

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.cri.passport.library.service.AccessTokenService;
 import uk.gov.di.ipv.cri.passport.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.cri.passport.library.service.ClientAuthJwtIdService;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.validation.ValidationResult;
 
@@ -54,7 +55,9 @@ public class AccessTokenHandler
         this.configurationService = new ConfigurationService();
         this.accessTokenService = new AccessTokenService(configurationService);
         this.authorizationCodeService = new AuthorizationCodeService(configurationService);
-        this.tokenRequestValidator = new TokenRequestValidator(configurationService);
+        this.tokenRequestValidator =
+                new TokenRequestValidator(
+                        configurationService, new ClientAuthJwtIdService(configurationService));
     }
 
     @Override

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -53,6 +53,7 @@ class AccessTokenHandlerTest {
                     Instant.now().toString(),
                     UUID.randomUUID().toString());
 
+    private static final String TEST_JWT_ID = "test-jwt-id";
     private final ObjectMapper objectMapper = new ObjectMapper();
     @Mock private Context context;
     @Mock private AccessTokenService mockAccessTokenService;
@@ -76,6 +77,7 @@ class AccessTokenHandlerTest {
 
         when(mockAccessTokenService.validateAuthorizationGrant(any()))
                 .thenReturn(ValidationResult.createValidResult());
+
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         Map<String, Object> responseBody =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
@@ -15,7 +15,9 @@ public class LogHelper {
         COMPONENT_ID_LOG_FIELD("componentId"),
         ERROR_CODE_LOG_FIELD("errorCode"),
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
-        PASSPORT_SESSION_ID_LOG_FIELD("passportSessionId");
+        PASSPORT_SESSION_ID_LOG_FIELD("passportSessionId"),
+        JTI_LOG_FIELD("jti"),
+        USED_AT_DATE_TIME_LOG_FIELD("usedAtDateTime");
 
         private final String fieldName;
 
@@ -23,7 +25,7 @@ public class LogHelper {
             this.fieldName = fieldName;
         }
 
-        String getFieldName() {
+        public String getFieldName() {
             return this.fieldName;
         }
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/ClientAuthJwtIdItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/ClientAuthJwtIdItem.java
@@ -1,0 +1,46 @@
+package uk.gov.di.ipv.cri.passport.library.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
+public class ClientAuthJwtIdItem implements DynamodbItem {
+    private String jwtId;
+    private String usedAtDateTime;
+    private long ttl;
+
+    // required for DynamoDb BeanTableSchema
+    public ClientAuthJwtIdItem() {}
+
+    public ClientAuthJwtIdItem(String jwtId, String usedAtDateTime) {
+        this.jwtId = jwtId;
+        this.usedAtDateTime = usedAtDateTime;
+    }
+
+    @DynamoDbPartitionKey
+    public String getJwtId() {
+        return jwtId;
+    }
+
+    public void setJwtId(String jwtId) {
+        this.jwtId = jwtId;
+    }
+
+    public String getUsedAtDateTime() {
+        return usedAtDateTime;
+    }
+
+    public void setUsedAtDateTime(String usedAtDateTime) {
+        this.usedAtDateTime = usedAtDateTime;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ClientAuthJwtIdService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ClientAuthJwtIdService.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.passport.library.service;
+
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.ClientAuthJwtIdItem;
+
+import java.time.Instant;
+
+public class ClientAuthJwtIdService {
+    private final DataStore<ClientAuthJwtIdItem> dataStore;
+    private final ConfigurationService configurationService;
+
+    @ExcludeFromGeneratedCoverageReport
+    public ClientAuthJwtIdService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.dataStore =
+                new DataStore<>(
+                        this.configurationService.getClientAuthJwtIdsTableName(),
+                        ClientAuthJwtIdItem.class,
+                        DataStore.getClient(
+                                this.configurationService.getDynamoDbEndpointOverride()),
+                        this.configurationService);
+    }
+
+    // For tests
+    public ClientAuthJwtIdService(
+            ConfigurationService configurationService, DataStore<ClientAuthJwtIdItem> dataStore) {
+        this.configurationService = configurationService;
+        this.dataStore = dataStore;
+    }
+
+    public ClientAuthJwtIdItem getClientAuthJwtIdItem(String jwtId) {
+        return dataStore.getItem(jwtId);
+    }
+
+    public void persistClientAuthJwtId(String jwtId) {
+        String timestamp = Instant.now().toString();
+        ClientAuthJwtIdItem clientAuthJwtIdItem = new ClientAuthJwtIdItem(jwtId, timestamp);
+        dataStore.create(clientAuthJwtIdItem);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/ConfigurationService.java
@@ -78,6 +78,10 @@ public class ConfigurationService {
         return System.getenv("CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME");
     }
 
+    public String getClientAuthJwtIdsTableName() {
+        return System.getenv("CRI_PASSPORT_CLIENT_AUTH_JWT_IDS_TABLE_NAME");
+    }
+
     public String getSqsAuditEventQueueUrl() {
         return System.getenv("SQS_AUDIT_EVENT_QUEUE_URL");
     }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ClientAuthJwtIdServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/ClientAuthJwtIdServiceTest.java
@@ -1,0 +1,51 @@
+package uk.gov.di.ipv.cri.passport.library.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.ClientAuthJwtIdItem;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ClientAuthJwtIdServiceTest {
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private DataStore<ClientAuthJwtIdItem> mockDataStore;
+    @InjectMocks private ClientAuthJwtIdService clientAuthJwtIdService;
+
+    @Test
+    void shouldReturnClientAuthJwtIdItemGivenJwtId() {
+        String testJwtId = "test-jwt-id";
+        String testTimestamp = Instant.now().toString();
+        ClientAuthJwtIdItem clientAuthJwtIdItem = new ClientAuthJwtIdItem(testJwtId, testTimestamp);
+        when(mockDataStore.getItem(testJwtId)).thenReturn(clientAuthJwtIdItem);
+
+        ClientAuthJwtIdItem result = clientAuthJwtIdService.getClientAuthJwtIdItem(testJwtId);
+
+        assertNotNull(result.getJwtId());
+        assertEquals(testJwtId, result.getJwtId());
+    }
+
+    @Test
+    void shouldPersistClientAuthJwtId() {
+        String testJwtId = "test-jwt-id";
+        ArgumentCaptor<ClientAuthJwtIdItem> clientAuthJwtIdItemArgCaptor =
+                ArgumentCaptor.forClass(ClientAuthJwtIdItem.class);
+
+        clientAuthJwtIdService.persistClientAuthJwtId(testJwtId);
+
+        verify(mockDataStore).create(clientAuthJwtIdItemArgCaptor.capture());
+        ClientAuthJwtIdItem capturedClientAuthJwtIdItem = clientAuthJwtIdItemArgCaptor.getValue();
+        assertNotNull(capturedClientAuthJwtIdItem);
+        assertEquals(testJwtId, capturedClientAuthJwtIdItem.getJwtId());
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Validate the JWT id (JTI) of the access token private key JWT request
- check that it is present in the JWT claims
- check that it is unique ie. has not already been used before, by storing previously used JWT ids

### Why did it change

OpenID Connect Core 1.0 Section 9 ([Final: OpenID Connect Core 1.0 incorporating errata set 1](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)) states that the private_key_jwt is required to contain a jti claim, which is a unique identifier for the JWT. It should be used to prevent re-use of the tokens, which MUST only be used once

### Issue tracking
- [PYIC-1450](https://govukverify.atlassian.net/browse/PYIC-1450)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

