### PR TITLE
BAU Fix installation of Checkov

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "deploy/template.yaml"
+      - ".github/workflows/checkov.yml"
 jobs:
   RunCheckov:
     runs-on: ubuntu-latest
@@ -18,6 +19,6 @@ jobs:
         with:
           python-version: 3.8
       - name: install checkov
-        run: pip3 install checkov
+        run: pip3 install --upgrade pip && pip3 install --upgrade setuptools && pip3 install checkov
       - name: run checkov
         run: checkov --directory deploy


### PR DESCRIPTION
Install setuptools before attempting to install checkov.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

### What changed
It seems that checkov has recently updated to 2.1.34 and now requires `setuptools` installed before it can be installed. This PR fixes the install but checkov check itself fails because it has new rules which were not previously met. They will be addressed in a separate PR.
<!-- Describe the changes in detail - the "what"-->
