### PR TITLE
BAU Address new Checkov Rules

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -154,7 +154,9 @@ Resources:
   IPVCriUKPassportIssueCredentialFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-passport-issue-credential-${Environment}"
       Handler: uk.gov.di.ipv.cri.passport.issuecredential.IssueCredentialHandler::handleRequest
       Runtime: java11
@@ -237,7 +239,9 @@ Resources:
   IPVCriUKPassportAccessTokenFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-passport-token-${Environment}"
       Handler: uk.gov.di.ipv.cri.passport.accesstoken.AccessTokenHandler::handleRequest
       Runtime: java11
@@ -304,7 +308,9 @@ Resources:
   IPVCriUKPassportAuthorizationCodeFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-passport-authorization-${Environment}"
       Handler: uk.gov.di.ipv.cri.passport.authorizationcode.AuthorizationCodeHandler::handleRequest
       Runtime: java11
@@ -387,7 +393,9 @@ Resources:
   IPVCriUKPassportJwTAuthorizationRequestFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-passport-jwt-authorization-request-${Environment}"
       Handler: uk.gov.di.ipv.cri.passport.jwtauthorizationrequest.JwtAuthorizationRequestHandler::handleRequest
       Runtime: java11


### PR DESCRIPTION
- CKW_AWS_117: We have future work to move the lambdas into our own VPC for greater
  egress controls but for now we are ok with them being in an AWS
  managed VPC
- CKW_AWS_115: Each account has an allocation of 1000 concurrent lambda
  executions per region. We do not have enough data to make informed
  decisions how this allocation might be best set on a per function
  basis. For now it makes sense to permit each function to draw on the
  allocations as they need it.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Version `2.1.34` of checkov introduced some new rules.

<!-- Describe the reason these changes were made - the "why" -->

