### PR TITLE
PYIC-1551: Create blank lambda code for the build-client-oauth-response lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -652,7 +652,6 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
-
   CRIPassportBackSessionsTable:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.

--- a/lambdas/buildclientoauthresponse/build.gradle
+++ b/lambdas/buildclientoauthresponse/build.gradle
@@ -1,0 +1,77 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+plugins {
+	id "java"
+	id "application"
+	id "idea"
+	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			project(":lib")
+
+	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-core:4.1.0",
+			"org.mockito:mockito-junit-jupiter:4.1.0",
+			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+}
+
+task buildZip(type: Zip) {
+	from compileJava
+	from processResources
+	destinationDirectory = file("$rootDir/dist")
+	into("lib") {
+		from configurations.runtimeClasspath
+	}
+}
+
+test {
+	useJUnitPlatform ()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
+}
+
+tasks.withType(Test) {
+	testLogging {
+		events TestLogEvent.FAILED,
+				TestLogEvent.PASSED,
+				TestLogEvent.SKIPPED
+
+		exceptionFormat TestExceptionFormat.FULL
+		showExceptions true
+		showCauses true
+		showStackTraces true
+
+		afterSuite { suite, result ->
+			if (!suite.parent) {
+				def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+				def startItem = "|  ", endItem = "  |"
+				def repeatLength = startItem.length() + output.length() + endItem.length()
+				println("\n" + ("-" * repeatLength) + "\n" + startItem + output + endItem + "\n" + ("-" * repeatLength))
+			}
+		}
+	}
+}

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.cri.passport.buildclientoauthresponse;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+public class BuildClientOauthResponseHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return null;
+    }
+}

--- a/lambdas/buildclientoauthresponse/src/main/resources/log4j2.yaml
+++ b/lambdas/buildclientoauthresponse/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
+  Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
+    Root:
+      level: info
+      AppenderRef:
+        ref: JsonAppender
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,5 +4,6 @@ include "lib",
 		"lambdas:accesstoken",
 		"lambdas:issuecredential",
 		"lambdas:authorizationcode",
+		"lambdas:buildclientoauthresponse",
 		"lambdas:initialisesession",
 		"integration-test"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create new empty gradle module for the new "build-client-oauth-response" lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This is the start of a new lambda that will be responsible for generating an Oauth response back to core, i.e generating an auth code and all the params needed to redirect back to core-front.


A further PR will be added to add the necessary AWS SAM config to start deploying this new lambda
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1551](https://govukverify.atlassian.net/browse/PYI-1551)

