### PR TITLE
PYIC-1553: Create auth code and return oauth redirect uri

### DIFF
--- a/lambdas/buildclientoauthresponse/build.gradle
+++ b/lambdas/buildclientoauthresponse/build.gradle
@@ -15,8 +15,10 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -4,13 +4,121 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.Logging;
+import uk.gov.di.ipv.cri.passport.buildclientoauthresponse.domain.ClientDetails;
+import uk.gov.di.ipv.cri.passport.buildclientoauthresponse.domain.ClientResponse;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
+import uk.gov.di.ipv.cri.passport.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
+import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportSessionItem;
+import uk.gov.di.ipv.cri.passport.library.service.AuditService;
+import uk.gov.di.ipv.cri.passport.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.service.PassportSessionService;
+
+import java.net.URISyntaxException;
 
 public class BuildClientOauthResponseHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private AuthorizationCodeService authorizationCodeService;
+    private PassportSessionService passportSessionService;
+    private AuditService auditService;
+    private ConfigurationService configurationService;
+
+    public BuildClientOauthResponseHandler(
+            AuthorizationCodeService authorizationCodeService,
+            PassportSessionService passportSessionService,
+            AuditService auditService,
+            ConfigurationService configurationService) {
+        this.authorizationCodeService = authorizationCodeService;
+        this.passportSessionService = passportSessionService;
+        this.auditService = auditService;
+        this.configurationService = configurationService;
+    }
+
+    public BuildClientOauthResponseHandler() {
+        this.configurationService = new ConfigurationService();
+        this.authorizationCodeService = new AuthorizationCodeService(configurationService);
+        this.passportSessionService = new PassportSessionService(configurationService);
+        this.auditService =
+                new AuditService(AuditService.getDefaultSqsClient(), configurationService);
+    }
 
     @Override
+    @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return null;
+        LogHelper.attachComponentIdToLogs();
+
+        try {
+            String passportSessionId = RequestHelper.getPassportSessionId(input);
+
+            PassportSessionItem passportSessionItem =
+                    passportSessionService.getPassportSession(passportSessionId);
+
+            AuthorizationCode authorizationCode =
+                    authorizationCodeService.generateAuthorizationCode();
+
+            authorizationCodeService.persistAuthorizationCode(
+                    authorizationCode.getValue(), passportSessionId);
+
+            ClientResponse clientResponse =
+                    generateClientSuccessResponse(
+                            passportSessionItem, authorizationCode.getValue());
+
+            auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, clientResponse);
+        } catch (HttpResponseExceptionWithErrorBody e) {
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getStatusCode(), e.getErrorResponse());
+        } catch (URISyntaxException e) {
+            LOGGER.error("Failed to construct redirect uri because: {}", e.getMessage());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (SqsException e) {
+            ErrorObject error = OAuth2Error.SERVER_ERROR.setDescription(e.getMessage());
+
+            LogHelper.logOauthError(
+                    "Failed to send message to aws SQS audit event queue",
+                    error.getCode(),
+                    error.getDescription());
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, error.toJSONObject());
+        }
+    }
+
+    private ClientResponse generateClientSuccessResponse(
+            PassportSessionItem passportSessionItem, String authorizationCode)
+            throws URISyntaxException {
+        URIBuilder redirectUri =
+                new URIBuilder(
+                                passportSessionItem
+                                        .getJarOauthParams()
+                                        .getAuthParams()
+                                        .getRedirectUri())
+                        .addParameter("code", authorizationCode);
+
+        if (StringUtils.isNotBlank(
+                passportSessionItem.getJarOauthParams().getAuthParams().getState())) {
+            redirectUri.addParameter(
+                    "state", passportSessionItem.getJarOauthParams().getAuthParams().getState());
+        }
+
+        return new ClientResponse(new ClientDetails(redirectUri.build().toString()));
     }
 }

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/domain/ClientDetails.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/domain/ClientDetails.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.cri.passport.buildclientoauthresponse.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@JsonInclude(Include.NON_EMPTY)
+public class ClientDetails {
+    @JsonProperty private final String redirectUrl;
+
+    @JsonCreator
+    public ClientDetails(@JsonProperty(value = "redirectUrl", required = true) String redirectUrl) {
+        this.redirectUrl = redirectUrl;
+    }
+
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+}

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/domain/ClientResponse.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/domain/ClientResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.cri.passport.buildclientoauthresponse.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class ClientResponse {
+    @JsonProperty private final ClientDetails client;
+
+    @JsonCreator
+    public ClientResponse(@JsonProperty(value = "client", required = true) ClientDetails client) {
+        this.client = client;
+    }
+
+    public ClientDetails getClient() {
+        return client;
+    }
+}

--- a/lambdas/buildclientoauthresponse/src/test/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/buildclientoauthresponse/src/test/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -1,0 +1,213 @@
+package uk.gov.di.ipv.cri.passport.buildclientoauthresponse;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.passport.buildclientoauthresponse.domain.ClientResponse;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
+import uk.gov.di.ipv.cri.passport.library.domain.JarOauthParams;
+import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
+import uk.gov.di.ipv.cri.passport.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportSessionItem;
+import uk.gov.di.ipv.cri.passport.library.service.AuditService;
+import uk.gov.di.ipv.cri.passport.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.service.PassportSessionService;
+
+import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BuildClientOauthResponseHandlerTest {
+    private static final String PASSPORT_SESSION_ID_HEADER_NAME = "passport_session_id";
+    private static final Map<String, String> TEST_EVENT_HEADERS =
+            Map.of(PASSPORT_SESSION_ID_HEADER_NAME, "12345");
+
+    @Mock private Context context;
+    @Mock private AuthorizationCodeService mockAuthorizationCodeService;
+    @Mock private PassportSessionService mockPassportSessionService;
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private AuditService mockAuditService;
+
+    private AuthorizationCode authorizationCode;
+    private BuildClientOauthResponseHandler handler;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        authorizationCode = new AuthorizationCode();
+        handler =
+                new BuildClientOauthResponseHandler(
+                        mockAuthorizationCodeService,
+                        mockPassportSessionService,
+                        mockAuditService,
+                        mockConfigurationService);
+    }
+
+    @Test
+    void shouldReturn200OnSuccessfulRequest()
+            throws JsonProcessingException, SqsException, URISyntaxException {
+        when(mockAuthorizationCodeService.generateAuthorizationCode())
+                .thenReturn(authorizationCode);
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(generatePassportSessionItem());
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        event.setHeaders(TEST_EVENT_HEADERS);
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        ClientResponse responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        verify(mockAuthorizationCodeService)
+                .persistAuthorizationCode(
+                        authorizationCode.getValue(),
+                        TEST_EVENT_HEADERS.get(PASSPORT_SESSION_ID_HEADER_NAME));
+
+        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+
+        String expectedRedirectUrl =
+                new URIBuilder("https://example.com")
+                        .addParameter("code", authorizationCode.toString())
+                        .addParameter("state", "test-state")
+                        .build()
+                        .toString();
+
+        assertEquals(expectedRedirectUrl, responseBody.getClient().getRedirectUrl());
+    }
+
+    @Test
+    void shouldReturn200WhenStateNotInSession() throws Exception {
+        when(mockAuthorizationCodeService.generateAuthorizationCode())
+                .thenReturn(authorizationCode);
+
+        PassportSessionItem passportSessionItem = generatePassportSessionItem();
+        passportSessionItem.getJarOauthParams().getAuthParams().setState(null);
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(TEST_EVENT_HEADERS);
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        ClientResponse responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        String expectedRedirectUrl =
+                new URIBuilder("https://example.com")
+                        .addParameter("code", authorizationCode.toString())
+                        .build()
+                        .toString();
+
+        assertEquals(expectedRedirectUrl, responseBody.getClient().getRedirectUrl());
+    }
+
+    @Test
+    void shouldReturn400WhenPassportSessionIdHeaderIsMissing() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER.getMessage(),
+                responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn500IfAuditServiceFails() throws SqsException, JsonProcessingException {
+        when(mockAuthorizationCodeService.generateAuthorizationCode())
+                .thenReturn(authorizationCode);
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(generatePassportSessionItem());
+        doThrow(new SqsException("Test error"))
+                .when(mockAuditService)
+                .sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        event.setHeaders(TEST_EVENT_HEADERS);
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(OAuth2Error.SERVER_ERROR.getCode(), responseBody.get("error"));
+        assertEquals("Test error", responseBody.get("error_description"));
+    }
+
+    @Test
+    void shouldReturn500OnInvalidUriStringForRedirectUri()
+            throws JsonProcessingException, SqsException, URISyntaxException {
+        when(mockAuthorizationCodeService.generateAuthorizationCode())
+                .thenReturn(authorizationCode);
+        PassportSessionItem passportSessionItem = generatePassportSessionItem();
+        passportSessionItem
+                .getJarOauthParams()
+                .getAuthParams()
+                .setRedirectUri("https://inv^alid.com");
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        event.setHeaders(TEST_EVENT_HEADERS);
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ;
+    }
+
+    private PassportSessionItem generatePassportSessionItem() {
+        PassportSessionItem item = new PassportSessionItem();
+
+        AuthParams authParams =
+                new AuthParams("code", "ipv-core", "test-state", "https://example.com");
+        JarOauthParams jarOauthParams = new JarOauthParams(authParams, "user-id");
+
+        item.setJarOauthParams(jarOauthParams);
+        item.setPassportSessionId(SecureTokenHelper.generate());
+        item.setCreationDateTime(new Date().toString());
+
+        return item;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/AuthorizationCodeItem.java
@@ -19,6 +19,7 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public AuthorizationCodeItem() {}
 
+    // TODO: Clean up - remove this constructor after new auth code lambda is used
     public AuthorizationCodeItem(
             String authCode,
             String resourceId,
@@ -28,6 +29,13 @@ public class AuthorizationCodeItem implements DynamodbItem {
         this.authCode = authCode;
         this.resourceId = resourceId;
         this.redirectUrl = redirectUrl;
+        this.creationDateTime = creationDateTime;
+        this.passportSessionId = passportSessionId;
+    }
+
+    public AuthorizationCodeItem(
+            String authCode, String creationDateTime, String passportSessionId) {
+        this.authCode = authCode;
         this.creationDateTime = creationDateTime;
         this.passportSessionId = passportSessionId;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuthorizationCodeService.java
@@ -51,6 +51,14 @@ public class AuthorizationCodeService {
                         passportSessionId));
     }
 
+    public void persistAuthorizationCode(String authorizationCode, String passportSessionId) {
+        dataStore.create(
+                new AuthorizationCodeItem(
+                        DigestUtils.sha256Hex(authorizationCode),
+                        Instant.now().toString(),
+                        passportSessionId));
+    }
+
     public void setIssuedAccessToken(String authorizationCode, String accessToken) {
         AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
         authorizationCodeItem.setIssuedAccessToken(DigestUtils.sha256Hex(accessToken));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create and persist an auth code that links to the passport back session.

Return the redirect uri with the auth code and state params appended.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This lambda will be used as a new way of issuing auth codes that are linked to the passport-back session rather than specific individual resource id's.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1553](https://govukverify.atlassian.net/browse/PYI-1553)

