### PR TITLE
PYIC-1556: Ensure we can create access tokens with null resource ID

### DIFF
--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AccessTokenServiceTest.java
@@ -103,6 +103,29 @@ class AccessTokenServiceTest {
     }
 
     @Test
+    void shouldPersistAccessTokenWhenResourceIdNull() {
+        String testPassportSessionId = UUID.randomUUID().toString();
+        AccessToken accessToken = new BearerAccessToken(3600L, null);
+        AccessTokenResponse accessTokenResponse =
+                new AccessTokenResponse(new Tokens(accessToken, null));
+        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
+                ArgumentCaptor.forClass(AccessTokenItem.class);
+
+        accessTokenService.persistAccessToken(accessTokenResponse, null, testPassportSessionId);
+
+        verify(mockDataStore).create(accessTokenItemArgCaptor.capture());
+        AccessTokenItem capturedAccessTokenItem = accessTokenItemArgCaptor.getValue();
+        assertNotNull(capturedAccessTokenItem);
+        assertNull(capturedAccessTokenItem.getResourceId());
+        assertEquals(testPassportSessionId, capturedAccessTokenItem.getPassportSessionId());
+        assertEquals(
+                DigestUtils.sha256Hex(
+                        accessTokenResponse.getTokens().getBearerAccessToken().getValue()),
+                capturedAccessTokenItem.getAccessToken());
+        assertNotNull(capturedAccessTokenItem.getAccessTokenExpiryDateTime());
+    }
+
+    @Test
     void shouldGetSessionIdByAccessTokenWhenValidAccessTokenProvided() {
         String testResourceId = UUID.randomUUID().toString();
         AccessToken accessToken = new BearerAccessToken();


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Ensure we can create access tokens with null resource ID

### Why did it change

When performing the token exchange the authcode table has an entry for
the dcs response resource id. Later changes will mean that this value
will be blank. Ensure that the code can accommodate the value being
blank, creating a token entry with a blank dcs resource id entry in that
case.

This adds a test that shows there is no issue with the value being
persisted being null

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1556](https://govukverify.atlassian.net/browse/PYI-1556)
