### PR TITLE
BAU: Do not expect to receive session ID in initialisesession λ

### DIFF
--- a/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
+++ b/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
@@ -18,7 +18,6 @@ import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.domain.JarResponse;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.error.RedirectErrorResponse;
-import uk.gov.di.ipv.cri.passport.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
@@ -80,7 +79,6 @@ public class InitialiseSessionHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            RequestHelper.getPassportSessionId(input);
             String clientId = RequestHelper.getHeaderByKey(input.getHeaders(), CLIENT_ID);
 
             if (StringUtils.isBlank(clientId)) {
@@ -125,9 +123,6 @@ public class InitialiseSessionHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE);
-        } catch (HttpResponseExceptionWithErrorBody e) {
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getStatusCode(), e.getErrorResponse());
         }
     }
 

--- a/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
+++ b/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
@@ -236,24 +236,6 @@ class InitialiseSessionHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfPassportSessionIdIsNotSet() throws JsonProcessingException {
-        var event = new APIGatewayProxyRequestEvent();
-        Map<String, String> noSessionId = new HashMap<>(TEST_EVENT_HEADERS);
-        noSessionId.remove("passport_session_id");
-        event.setHeaders(noSessionId);
-
-        var response = underTest.handleRequest(event, context);
-
-        Map<String, Object> error =
-                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER.getCode(), error.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_PASSPORT_SESSION_ID_HEADER.getMessage(),
-                error.get("message"));
-    }
-
-    @Test
     void shouldReturn302WhenValidationFails() throws Exception {
         when(jarValidator.decryptJWE(any(JWEObject.class))).thenReturn(signedJWT);
         when(jarValidator.validateRequestJwt(any(), anyString()))


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Do not expect to receive session ID in initialisesession λ

### Why did it change

We were previously passing in the frontend's session ID in a header to
the jwt auth λ. Now that we're generating the session ID in the back we
don't need to do this and shouldn't throw if it's not there.

