### PR TITLE
PYIC-1559: When performing the passport check, update the session’s DCS resource entry to contain the resource id of the newly saved dcs result.

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
@@ -65,4 +65,16 @@ public class PassportSessionService {
 
         return passportSessionItem.getPassportSessionId();
     }
+
+    public void setLatestDcsResponseResourceId(String passportSessionID, String resourceId) {
+        PassportSessionItem passportSessionItem = dataStore.getItem(passportSessionID);
+        passportSessionItem.setLatestDcsResponseResourceId(resourceId);
+        dataStore.update(passportSessionItem);
+    }
+
+    public void incrementAttemptCount(String passportSessionID) {
+        PassportSessionItem passportSessionItem = dataStore.getItem(passportSessionID);
+        passportSessionItem.setAttemptCount(passportSessionItem.getAttemptCount() + 1);
+        dataStore.update(passportSessionItem);
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionServiceTest.java
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PassportSessionServiceTest {
     @Mock ConfigurationService configurationService;
-    @Mock DataStore<PassportSessionItem> dataStore;
+    @Mock DataStore<PassportSessionItem> mockDataStore;
 
     private PassportSessionService underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new PassportSessionService(dataStore, configurationService);
+        underTest = new PassportSessionService(mockDataStore, configurationService);
     }
 
     @Test
@@ -39,13 +39,13 @@ class PassportSessionServiceTest {
         passportSessionItem.setPassportSessionId(passportSessionID);
         passportSessionItem.setCreationDateTime(new Date().toString());
 
-        when(dataStore.getItem(passportSessionID)).thenReturn(passportSessionItem);
+        when(mockDataStore.getItem(passportSessionID)).thenReturn(passportSessionItem);
 
         PassportSessionItem result = underTest.getPassportSession(passportSessionID);
 
         ArgumentCaptor<String> passportSessionIDArgumentCaptor =
                 ArgumentCaptor.forClass(String.class);
-        verify(dataStore).getItem(passportSessionIDArgumentCaptor.capture());
+        verify(mockDataStore).getItem(passportSessionIDArgumentCaptor.capture());
         assertEquals(passportSessionID, passportSessionIDArgumentCaptor.getValue());
         assertEquals(passportSessionItem.getPassportSessionId(), result.getPassportSessionId());
         assertEquals(passportSessionItem.getCreationDateTime(), result.getCreationDateTime());
@@ -63,10 +63,42 @@ class PassportSessionServiceTest {
 
         ArgumentCaptor<PassportSessionItem> passportSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(PassportSessionItem.class);
-        verify(dataStore).create(passportSessionItemArgumentCaptor.capture());
+        verify(mockDataStore).create(passportSessionItemArgumentCaptor.capture());
         assertNotNull(passportSessionItemArgumentCaptor.getValue().getCreationDateTime());
         assertEquals(
                 passportSessionItemArgumentCaptor.getValue().getPassportSessionId(),
                 passportSessionID);
+    }
+
+    @Test
+    void shouldUpdateLatestDcsResponseResourceId() {
+        String passportSessionID = SecureTokenHelper.generate();
+        String latestDcsResponseResourceId = "test";
+
+        when(mockDataStore.getItem(passportSessionID)).thenReturn(new PassportSessionItem());
+        underTest.setLatestDcsResponseResourceId(passportSessionID, latestDcsResponseResourceId);
+
+        ArgumentCaptor<PassportSessionItem> passportSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(PassportSessionItem.class);
+        verify(mockDataStore).update(passportSessionItemArgumentCaptor.capture());
+        assertEquals(
+                passportSessionItemArgumentCaptor.getValue().getLatestDcsResponseResourceId(),
+                latestDcsResponseResourceId);
+    }
+
+    @Test
+    void shouldIncrementAttemptCount() {
+        String passportSessionID = SecureTokenHelper.generate();
+
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setAttemptCount(1);
+
+        when(mockDataStore.getItem(passportSessionID)).thenReturn(passportSessionItem);
+        underTest.incrementAttemptCount(passportSessionID);
+
+        ArgumentCaptor<PassportSessionItem> passportSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(PassportSessionItem.class);
+        verify(mockDataStore).update(passportSessionItemArgumentCaptor.capture());
+        assertEquals(passportSessionItemArgumentCaptor.getValue().getAttemptCount(), 2);
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- When performing the passport check, update the session’s DCS resource entry to contain the resource id of the newly saved DCS result.

- Increment attempt count.

- Continue returning authcode.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1559](https://govukverify.atlassian.net/browse/PYI-1559)
