### PR TITLE
PYIC-1594 Fix Deployment of New Lambdas

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -322,6 +322,8 @@ Resources:
 
   IPVCriUKPassportCheckPassportFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - "IPVCriUKPassportCheckPassportFunctionLogGroup"
     Properties:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
@@ -404,7 +406,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportCheckPassportFunction}"
+      LogGroupName: !Sub "/aws/lambda/ipv-passport-check-passport-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   IPVCriUKPassportCheckPassportFunctionLogGroupSubscriptionFilter:
@@ -417,6 +419,8 @@ Resources:
 
   IPVCriUKPassportBuildClientOauthResponseFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - IPVCriUKPassportBuildClientOauthResponseFunctionLogGroup
     Properties:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
@@ -471,7 +475,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/${IPVCriUKPassportBuildClientOauthResponseFunction}"
+      LogGroupName: !Sub "/aws/lambda/ipv-passport-build-client-oauth-response-${Environment}"
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   IPVCriUKPassportBuildClientOauthResponseFunctionLogGroupSubscriptionFilter:


### PR DESCRIPTION
The `AWS::Serverless::Function` will create a log group if one does not
exist with the expected log group name. We define our log groups in the
template rather than relying on the serverless transform because we want
to set the retention period. The initial PR introduced two new functions
and their log groups, the log group definition referenced the function
which meant the function would be created first, causing a "log group
with the same name exists" error when eventually CFN came to create the
log group resource. This change adds a depends on between the function
and the log group so the log group should be created first.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->
This has been tested in passport development A environment with @dannyhayes-gds 
### Why did it change
As above.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1594](https://govukverify.atlassian.net/browse/PYI-1594)
