### PR TITLE
PYIC-1606: Stop generating auth code in passport check lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -342,7 +342,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           DCS_RESPONSE_TABLE_NAME: !Select [1, !Split ['/', !GetAtt DCSResponseTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
-          CRI_PASSPORT_AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAuthCodesTable.Arn]]
           DCS_ENCRYPTION_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/encryptionCertForPassportToEncrypt"
           DCS_SIGNING_CERT_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/dcs/signingCertForPassportToVerify"
           PASSPORT_CRI_SIGNING_KEY_PARAM: !Sub "/${Environment}/credentialIssuers/ukPassport/self/signingKeyForPassportToSign"
@@ -366,8 +365,6 @@ Resources:
             TableName: !Ref CRIPassportAccessTokensTable
         - DynamoDBCrudPolicy:
             TableName: !Ref CRIPassportBackSessionsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref CRIPassportAuthCodesTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/*
         - SSMParameterReadPolicy:

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSObject;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -44,7 +43,6 @@ import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
 import uk.gov.di.ipv.cri.passport.library.helpers.RequestHelper;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 import uk.gov.di.ipv.cri.passport.library.service.AuditService;
-import uk.gov.di.ipv.cri.passport.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.DcsCryptographyService;
 import uk.gov.di.ipv.cri.passport.library.service.PassportService;
@@ -74,10 +72,8 @@ public class CheckPassportHandler
     public static final String RESULT = "result";
     public static final String RESULT_FINISH = "finish";
     public static final String RESULT_RETRY = "retry";
-    public static final String AUTHORIZATION_CODE = "code";
 
     private final PassportService passportService;
-    private final AuthorizationCodeService authorizationCodeService;
     private final ConfigurationService configurationService;
     private final DcsCryptographyService dcsCryptographyService;
     private final AuditService auditService;
@@ -87,14 +83,12 @@ public class CheckPassportHandler
 
     public CheckPassportHandler(
             PassportService passportService,
-            AuthorizationCodeService authorizationCodeService,
             ConfigurationService configurationService,
             DcsCryptographyService dcsCryptographyService,
             AuditService auditService,
             AuthRequestValidator authRequestValidator,
             PassportSessionService passportSessionService) {
         this.passportService = passportService;
-        this.authorizationCodeService = authorizationCodeService;
         this.configurationService = configurationService;
         this.dcsCryptographyService = dcsCryptographyService;
         this.auditService = auditService;
@@ -107,7 +101,6 @@ public class CheckPassportHandler
                     KeyStoreException, IOException {
         this.configurationService = new ConfigurationService();
         this.passportService = new PassportService(configurationService);
-        this.authorizationCodeService = new AuthorizationCodeService(configurationService);
         this.dcsCryptographyService = new DcsCryptographyService(configurationService);
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
@@ -168,21 +161,12 @@ public class CheckPassportHandler
                             authenticationRequest.getClientID().getValue());
             passportService.persistDcsResponse(passportCheckDao);
 
-            AuthorizationCode authorizationCode =
-                    authorizationCodeService.generateAuthorizationCode();
-            authorizationCodeService.persistAuthorizationCode(
-                    authorizationCode.getValue(),
-                    passportCheckDao.getResourceId(),
-                    authenticationRequest.getRedirectionURI().toString(),
-                    passportSessionId);
-
             auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
 
             passportSessionService.setLatestDcsResponseResourceId(
                     passportSessionId, passportCheckDao.getResourceId());
 
-            return validateResponseAndAttemptCount(
-                    passportSessionId, unwrappedDcsResponse, authorizationCode);
+            return validateResponseAndAttemptCount(passportSessionId, unwrappedDcsResponse);
 
         } catch (OAuthHttpResponseExceptionWithErrorBody e) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
@@ -214,9 +198,7 @@ public class CheckPassportHandler
     }
 
     private APIGatewayProxyResponseEvent validateResponseAndAttemptCount(
-            String passportSessionId,
-            DcsResponse unwrappedDcsResponse,
-            AuthorizationCode authorizationCode) {
+            String passportSessionId, DcsResponse unwrappedDcsResponse) {
 
         int attemptCount =
                 passportSessionService.getPassportSession(passportSessionId).getAttemptCount();
@@ -224,13 +206,11 @@ public class CheckPassportHandler
         if (unwrappedDcsResponse.isValid()
                 || attemptCount >= configurationService.getMaximumAttemptCount()) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK,
-                    Map.of(AUTHORIZATION_CODE, authorizationCode, RESULT, RESULT_FINISH));
+                    HttpStatus.SC_OK, Map.of(RESULT, RESULT_FINISH));
         }
 
         return ApiGatewayResponseGenerator.proxyJsonResponse(
-                HttpStatus.SC_OK,
-                Map.of(AUTHORIZATION_CODE, authorizationCode, RESULT, RESULT_RETRY));
+                HttpStatus.SC_OK, Map.of(RESULT, RESULT_RETRY));
     }
 
     private AuditEvent createAuditEventRequestSent(

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSObject;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +31,6 @@ import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportCheckDao;
 import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportSessionItem;
 import uk.gov.di.ipv.cri.passport.library.service.AuditService;
-import uk.gov.di.ipv.cri.passport.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.cri.passport.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.service.DcsCryptographyService;
 import uk.gov.di.ipv.cri.passport.library.service.PassportService;
@@ -54,7 +52,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -101,7 +98,6 @@ class CheckPassportHandlerTest {
 
     @Mock Context context;
     @Mock PassportService passportService;
-    @Mock AuthorizationCodeService authorizationCodeService;
     @Mock ConfigurationService configurationService;
     @Mock DcsCryptographyService dcsCryptographyService;
     @Mock PassportSessionService passportSessionService;
@@ -110,15 +106,12 @@ class CheckPassportHandlerTest {
     @Mock JWSObject jwsObject;
 
     private CheckPassportHandler underTest;
-    private AuthorizationCode authorizationCode;
 
     @BeforeEach
     void setUp() {
-        authorizationCode = new AuthorizationCode();
         underTest =
                 new CheckPassportHandler(
                         passportService,
-                        authorizationCodeService,
                         configurationService,
                         dcsCryptographyService,
                         auditService,
@@ -182,30 +175,6 @@ class CheckPassportHandlerTest {
                 VALID_PASSPORT_EVIDENCE.getValidityScore(),
                 persistedPassportCheckDao.getValue().getEvidence().getValidityScore());
         assertNull(persistedPassportCheckDao.getValue().getEvidence().getCi());
-    }
-
-    @Test
-    void shouldPersistAndReturnAuthorizationCode()
-            throws CertificateException, IOException, NoSuchAlgorithmException,
-                    InvalidKeySpecException, ParseException, EmptyDcsResponseException,
-                    JOSEException {
-        mockDcsResponse(validDcsResponse);
-        mockPassportSessionItem(0);
-
-        APIGatewayProxyRequestEvent event =
-                getApiGatewayProxyRequestEvent(
-                        "12345", objectMapper.writeValueAsString(validPassportFormData));
-
-        Map<String, Object> responseBody = getResponseBody(underTest.handleRequest(event, context));
-
-        Map<String, String> authCode = (Map<String, String>) responseBody.get("code");
-        verify(authorizationCodeService)
-                .persistAuthorizationCode(
-                        eq(authorizationCode.toString()),
-                        anyString(),
-                        eq(TEST_REDIRECT_URI),
-                        eq(PASSPORT_SESSION_ID));
-        assertEquals(authorizationCode.toString(), authCode.get("value"));
     }
 
     @Test
@@ -435,7 +404,6 @@ class CheckPassportHandlerTest {
         when(dcsCryptographyService.unwrapDcsResponse(any(DcsSignedEncryptedResponse.class)))
                 .thenReturn(validDcsResponse);
         when(authRequestValidator.validateRequest(any(), anyString())).thenReturn(Optional.empty());
-        when(authorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
     }
 
     private void mockPassportSessionItem(int attemptCount) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Stop generating an auth code in the passport check lambda and only return a "retry"/"finish" response.

Remove unnecessary DynamoDB permission to the auth code table and extra env var that is no longer needed.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The auth code is now generated in a different lambda so this auth code is not being used.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1606](https://govukverify.atlassian.net/browse/PYI-1606)

