### PR TITLE
BAU Fix Drift In Staging Environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -54,6 +54,14 @@ Conditions:
   IsNotDevelopmentEnvironment: !Not
     - Condition: IsDevelopmentEnvironment
 
+  #Temporary condition to resolve stack drift in staging
+  IsNotStagingOrDevelopment: !Not
+  - !Or 
+    - !Equals [ !Ref Environment, "development-a"]
+    - !Equals [ !Ref Environment, "development-b"]
+    - !Equals [ !Ref Environment, "development-c"]
+    - !Equals [ !Ref Environment, "staging"]
+
 Resources:
   IPVCriUKPassportPrivateAPI:
     Type: AWS::Serverless::Api
@@ -109,7 +117,9 @@ Resources:
 
   IPVCriUKPassportPrivateAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopmentEnvironment
+    #Condition: IsNotDevelopmentEnvironment
+    #Temporary condition to resolve stack drift in staging
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -151,7 +161,9 @@ Resources:
 
   IPVCriUKPassportAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopmentEnvironment
+    #Condition: IsNotDevelopmentEnvironment
+    #Temporary condition to resolve stack drift in staging
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -239,7 +251,9 @@ Resources:
 
   IPVCriUKPassportIssueCredentialFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopmentEnvironment
+    #Condition: IsNotDevelopmentEnvironment
+    #Temporary condition to resolve stack drift in staging
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -314,7 +328,9 @@ Resources:
 
   IPVCriUKPassportAccessTokenFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopmentEnvironment
+    #Condition: IsNotDevelopmentEnvironment
+    #Temporary condition to resolve stack drift in staging
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -566,7 +582,9 @@ Resources:
 
   IPVCriUKPassportInitialiseSessionFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopmentEnvironment
+    #Condition: IsNotDevelopmentEnvironment
+    #Temporary condition to resolve stack drift in staging
+    Condition: IsNotStagingOrDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""


### PR DESCRIPTION
Whilst an engineer was fixing the failed deployment of the passport back
stack in staging they removed the log groups. Although those log groups
have been manually put back the log group subscription filters are still
missing. CFN will not recreate them unless we:
1. Remove the resources from the stack so that the stack's view matches
   reality
2. Then add the resources back in so that CFN will recreate them.

This introduces a temporary condition to remove the missing log group
subscription filters for the Staging environment. Once deployed we will
then remove this change and CFN will recreate them.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above.
### What changed
As above.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The following resources have bene deleted manually and we need to put them back. Until this happens logs for these resources will not be sent to Splunk. I would prefer we gain experience in doing this via the CFN process which admittedly is onerous...

Drift detection results for `DELETE` resources.
```
GDS11321:logGroups dan.worth$ aws-vault exec passport-staging-admin -- aws cloudformation describe-stack-resource-drifts --stack-name ipv-passport-back-staging | jq '.StackResourceDrifts[] | select(.StackResourceDriftStatus == "DELETED").LogicalResourceId' -r
IPVCriUKPassportAPILogGroupSubscriptionFilter
IPVCriUKPassportAccessTokenFunctionLogGroupSubscriptionFilter
IPVCriUKPassportInitialiseSessionFunctionLogGroupSubscriptionFilter
IPVCriUKPassportIssueCredentialFunctionLogGroupSubscriptionFilter
IPVCriUKPassportPrivateAPILogGroupSubscriptionFilter
```
<!-- Describe the reason these changes were made - the "why" -->