### PR TITLE
Revert "BAU Fix Drift In Staging Environment"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -54,14 +54,6 @@ Conditions:
   IsNotDevelopmentEnvironment: !Not
     - Condition: IsDevelopmentEnvironment
 
-  #Temporary condition to resolve stack drift in staging
-  IsNotStagingOrDevelopment: !Not
-  - !Or 
-    - !Equals [ !Ref Environment, "development-a"]
-    - !Equals [ !Ref Environment, "development-b"]
-    - !Equals [ !Ref Environment, "development-c"]
-    - !Equals [ !Ref Environment, "staging"]
-
 Resources:
   IPVCriUKPassportPrivateAPI:
     Type: AWS::Serverless::Api
@@ -117,9 +109,7 @@ Resources:
 
   IPVCriUKPassportPrivateAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    #Condition: IsNotDevelopmentEnvironment
-    #Temporary condition to resolve stack drift in staging
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -161,9 +151,7 @@ Resources:
 
   IPVCriUKPassportAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    #Condition: IsNotDevelopmentEnvironment
-    #Temporary condition to resolve stack drift in staging
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -251,9 +239,7 @@ Resources:
 
   IPVCriUKPassportIssueCredentialFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    #Condition: IsNotDevelopmentEnvironment
-    #Temporary condition to resolve stack drift in staging
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -328,9 +314,7 @@ Resources:
 
   IPVCriUKPassportAccessTokenFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    #Condition: IsNotDevelopmentEnvironment
-    #Temporary condition to resolve stack drift in staging
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
@@ -582,9 +566,7 @@ Resources:
 
   IPVCriUKPassportInitialiseSessionFunctionLogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    #Condition: IsNotDevelopmentEnvironment
-    #Temporary condition to resolve stack drift in staging
-    Condition: IsNotStagingOrDevelopment
+    Condition: IsNotDevelopmentEnvironment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""


### PR DESCRIPTION
This reverts commit f6dfdb4aa99a983929672ad32c7671713994e003.

The above commit was made to address the stack drift for passport back in
the staging environment. That commit has been deployed so reverting it
will make CFN recreate the missing log group subscription filters.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Please see: https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/204

The above PR has been deployed through all environments:
https://cd.gds-reliability.engineering/teams/di-ipv/pipelines/cri-passport-deploy-to-production/jobs/deploy-passport-back/builds/53

There is no drift on the stack caused by `DELETED` resources
```
GDS11321:logGroups dan.worth$ aws-vault exec passport-staging-admin -- aws cloudformation describe-stack-resource-drifts --stack-name ipv-passport-back-staging | jq '.StackResourceDrifts[] | select(.StackResourceDriftStatus == "DELETED").LogicalResourceId' -r
GDS11321:logGroups dan.worth$
```

This will make CFN recreate the missing log group subscription filters.
