### PR TITLE
PYIC-1609: Stop sending the oauth params back from the initialise session lambda

### DIFF
--- a/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
+++ b/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.domain.JarResponse;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.error.RedirectErrorResponse;
@@ -44,10 +43,7 @@ public class InitialiseSessionHandler
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Integer OK = 200;
     private static final Integer BAD_REQUEST = 400;
-    private static final String RESPONSE_TYPE = "response_type";
     private static final String CLIENT_ID = "client_id";
-    private static final String STATE = "state";
-    private static final String REDIRECT_URI = "redirect_uri";
     private static final String SHARED_CLAIMS = "shared_claims";
 
     public InitialiseSessionHandler(
@@ -128,17 +124,6 @@ public class InitialiseSessionHandler
 
     private JarResponse generateJarResponse(JWTClaimsSet claimsSet, String passportSessionId)
             throws ParseException {
-        AuthParams authParams =
-                new AuthParams(
-                        claimsSet.getStringClaim(RESPONSE_TYPE),
-                        claimsSet.getStringClaim(CLIENT_ID),
-                        claimsSet.getStringClaim(STATE),
-                        claimsSet.getStringClaim(REDIRECT_URI));
-
-        return new JarResponse(
-                authParams,
-                claimsSet.getSubject(),
-                claimsSet.getJSONObjectClaim(SHARED_CLAIMS),
-                passportSessionId);
+        return new JarResponse(claimsSet.getJSONObjectClaim(SHARED_CLAIMS), passportSessionId);
     }
 }

--- a/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
+++ b/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
@@ -23,7 +23,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.passport.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.cri.passport.library.exceptions.RecoverableJarValidationException;
@@ -138,15 +137,6 @@ class InitialiseSessionHandlerTest {
 
         Map<String, Object> claims =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-
-        AuthParams authParams =
-                OBJECT_MAPPER.convertValue(claims.get("authParams"), new TypeReference<>() {});
-
-        assertEquals("test-user-id", claims.get("user_id"));
-        assertEquals("code", authParams.getResponseType());
-        assertEquals("test-client", authParams.getClientId());
-        assertEquals("test-state", authParams.getState());
-        assertEquals("http://example.com", authParams.getRedirectUri());
 
         Map<String, Object> sharedClaims =
                 OBJECT_MAPPER.convertValue(claims.get("shared_claims"), new TypeReference<>() {});

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/JarResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/JarResponse.java
@@ -7,35 +7,15 @@ import java.util.Map;
 
 @ExcludeFromGeneratedCoverageReport
 public class JarResponse {
-    @JsonProperty("authParams")
-    private AuthParams authParams;
-
-    @JsonProperty("user_id")
-    private String userId;
-
     @JsonProperty("shared_claims")
     private Map<String, Object> sharedClaims;
 
     @JsonProperty("passportSessionId")
     private String passportSessionId;
 
-    public JarResponse(
-            AuthParams authParams,
-            String userId,
-            Map<String, Object> sharedClaims,
-            String passportSessionId) {
-        this.authParams = authParams;
-        this.userId = userId;
+    public JarResponse(Map<String, Object> sharedClaims, String passportSessionId) {
         this.sharedClaims = sharedClaims;
         this.passportSessionId = passportSessionId;
-    }
-
-    public AuthParams getAuthParams() {
-        return authParams;
-    }
-
-    public String getUserId() {
-        return userId;
     }
 
     public Map<String, Object> getSharedClaims() {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Stop returning the oauth params from the initialise session lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These params are now stored in the back-end session so they don't need to be passed back to the front-end. The params will just be loaded from the back-end session DynamoDB and be used when needed.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1609](https://govukverify.atlassian.net/browse/PYI-1609)
