### PR TITLE
PYIC-1638 Update Passport CRI Backend to handle escape route

### DIFF
--- a/lambdas/buildclientoauthresponse/build.gradle
+++ b/lambdas/buildclientoauthresponse/build.gradle
@@ -15,19 +15,10 @@ repositories {
 dependencies {
 
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
-			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
-			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"

--- a/lambdas/buildclientoauthresponse/build.gradle
+++ b/lambdas/buildclientoauthresponse/build.gradle
@@ -15,9 +15,19 @@ repositories {
 dependencies {
 
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -69,6 +69,18 @@ public class BuildClientOauthResponseHandler
             PassportSessionItem passportSessionItem =
                     passportSessionService.getPassportSession(passportSessionId);
 
+            if (passportSessionItem.getAttemptCount() == 0) {
+                LOGGER.info(
+                        "No passport details attempt has been made - returning Access Denied response");
+                auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        OAuth2Error.ACCESS_DENIED.getHTTPStatusCode(),
+                        OAuth2Error.ACCESS_DENIED
+                                .appendDescription(" - No passport details attempt has been made")
+                                .toJSONObject());
+            }
+
             AuthorizationCode authorizationCode =
                     authorizationCodeService.generateAuthorizationCode();
 


### PR DESCRIPTION
## Proposed changes

### What changed

If no passport details attempt has been made (attemptCount = 0) return an AccessDenied response

### Why did it change

So we can handle the new 'escape route' on passport front if the user leaves the journey to prove their identity another way

### Issue tracking
- [PYIC-1638](https://govukverify.atlassian.net/browse/PYIC-1638)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
