### PR TITLE
PYIC-1759: Add govuk_signin_journey_id to application logs and txma audit events

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandler.java
@@ -102,6 +102,13 @@ public class AccessTokenHandler
             }
             LogHelper.attachPassportSessionIdToLogs(authorizationCodeItem.getPassportSessionId());
 
+            PassportSessionItem passportSessionItem =
+                    passportSessionService.getPassportSession(
+                            authorizationCodeItem.getPassportSessionId());
+
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    passportSessionItem.getGovukSigninJourneyId());
+
             if (authorizationCodeItem.getIssuedAccessToken() != null) {
                 LOGGER.error(
                         "Auth code has been used multiple times. Auth code was exchanged for an access token at: {}",
@@ -121,10 +128,6 @@ public class AccessTokenHandler
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
-
-            PassportSessionItem passportSessionItem =
-                    passportSessionService.getPassportSession(
-                            authorizationCodeItem.getPassportSessionId());
 
             if (redirectUrlsDoNotMatch(passportSessionItem, authorizationGrant)) {
                 LOGGER.error(

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -222,6 +222,11 @@ class AccessTokenHandlerTest {
         when(mockAuthorizationCodeService.getAuthCodeItem("12345")).thenReturn(TEST_AUTH_CODE_ITEM);
         when(mockAuthorizationCodeService.isExpired(TEST_AUTH_CODE_ITEM)).thenReturn(true);
 
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId(UUID.randomUUID().toString());
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
@@ -304,6 +309,12 @@ class AccessTokenHandlerTest {
 
         when(mockAccessTokenService.validateAuthorizationGrant(any()))
                 .thenReturn(ValidationResult.createValidResult());
+
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId(UUID.randomUUID().toString());
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         verify(mockAccessTokenService)
@@ -344,6 +355,11 @@ class AccessTokenHandlerTest {
         doThrow(new IllegalArgumentException(errorMessage))
                 .when(mockAccessTokenService)
                 .revokeAccessToken(any());
+
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId(UUID.randomUUID().toString());
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 

--- a/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/buildclientoauthresponse/src/main/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -69,13 +69,17 @@ public class BuildClientOauthResponseHandler
             PassportSessionItem passportSessionItem =
                     passportSessionService.getPassportSession(passportSessionId);
 
+            String govukSigninJourneyId = passportSessionItem.getGovukSigninJourneyId();
+            LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
+
             if (passportSessionItem.getAttemptCount() == 0) {
                 LOGGER.info(
                         "No passport details attempt has been made - returning Access Denied response");
 
                 ClientResponse clientResponse = generateClientErrorResponse(passportSessionItem);
 
-                auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+                auditService.sendAuditEvent(
+                        AuditEventTypes.IPV_PASSPORT_CRI_END, govukSigninJourneyId);
 
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatus.SC_OK, clientResponse);
@@ -91,7 +95,7 @@ public class BuildClientOauthResponseHandler
                     generateClientSuccessResponse(
                             passportSessionItem, authorizationCode.getValue());
 
-            auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+            auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END, govukSigninJourneyId);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, clientResponse);
         } catch (HttpResponseExceptionWithErrorBody e) {

--- a/lambdas/buildclientoauthresponse/src/test/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/buildclientoauthresponse/src/test/java/uk/gov/di/ipv/cri/passport/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -89,7 +89,9 @@ class BuildClientOauthResponseHandlerTest {
                         authorizationCode.getValue(),
                         TEST_EVENT_HEADERS.get(PASSPORT_SESSION_ID_HEADER_NAME));
 
-        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+        verify(mockAuditService)
+                .sendAuditEvent(
+                        AuditEventTypes.IPV_PASSPORT_CRI_END, "test-govuk-signin-journey-id");
 
         String expectedRedirectUrl =
                 new URIBuilder("https://example.com")
@@ -155,7 +157,8 @@ class BuildClientOauthResponseHandlerTest {
                 .thenReturn(generatePassportSessionItem());
         doThrow(new SqsException("Test error"))
                 .when(mockAuditService)
-                .sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+                .sendAuditEvent(
+                        AuditEventTypes.IPV_PASSPORT_CRI_END, "test-govuk-signin-journey-id");
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
@@ -230,6 +233,7 @@ class BuildClientOauthResponseHandlerTest {
 
         item.setAuthParams(authParams);
         item.setPassportSessionId(SecureTokenHelper.generate());
+        item.setGovukSigninJourneyId("test-govuk-signin-journey-id");
         item.setCreationDateTime(new Date().toString());
         item.setUserId("user-id");
         item.setAttemptCount(1);

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
@@ -130,7 +130,9 @@ class CheckPassportHandlerTest {
                 AuditEventTypes.IPV_PASSPORT_CRI_RESPONSE_RECEIVED,
                 capturedValues.get(1).getEventName());
 
-        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_END);
+        verify(auditService)
+                .sendAuditEvent(
+                        AuditEventTypes.IPV_PASSPORT_CRI_END, "test-govuk-signin-journey-id");
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
@@ -368,6 +370,7 @@ class CheckPassportHandlerTest {
         PassportSessionItem passportSessionItem = new PassportSessionItem();
         passportSessionItem.setAttemptCount(attemptCount);
         passportSessionItem.setUserId("test-user-id");
+        passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
         passportSessionItem.setAuthParams(
                 new AuthParams("code", "12345", "read", "https://example.com"));
 

--- a/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
+++ b/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
@@ -91,7 +91,7 @@ public class InitialiseSessionHandler
                         BAD_REQUEST, ErrorResponse.MISSING_SHARED_ATTRIBUTES_JWT);
             }
 
-            this.auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_START);
+            this.auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_START, null);
 
             SignedJWT signedJWT = jarValidator.decryptJWE(JWEObject.parse(input.getBody()));
 

--- a/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
+++ b/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
@@ -113,7 +113,7 @@ class InitialiseSessionHandlerTest {
 
         var response = underTest.handleRequest(event, context);
         assertEquals(200, response.getStatusCode());
-        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_START);
+        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_START, null);
     }
 
     @Test

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -136,6 +136,11 @@ class IssueCredentialHandlerTest {
         when(mockDcsPassportCheckService.getDcsPassportCheck(anyString()))
                 .thenReturn(passportCheckDao);
 
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
         mockConfigurationServiceCalls();
 
         APIGatewayProxyResponseEvent response =
@@ -217,6 +222,11 @@ class IssueCredentialHandlerTest {
         when(mockConfigurationService.getClientIssuer(clientId))
                 .thenReturn("https://example.com/issuer");
         mockConfigurationServiceCalls();
+
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
 
         APIGatewayProxyResponseEvent response =
                 issueCredentialHandler.handleRequest(event, mockContext);
@@ -402,6 +412,11 @@ class IssueCredentialHandlerTest {
         when(mockAccessTokenService.getAccessTokenItem(accessToken.getValue()))
                 .thenReturn(accessTokenItem);
 
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
+
         APIGatewayProxyResponseEvent response =
                 issueCredentialHandler.handleRequest(event, mockContext);
         Map<String, Object> responseBody =
@@ -433,6 +448,11 @@ class IssueCredentialHandlerTest {
 
         when(mockAccessTokenService.getAccessTokenItem(accessToken.getValue()))
                 .thenReturn(accessTokenItem);
+
+        PassportSessionItem passportSessionItem = new PassportSessionItem();
+        passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
+        when(mockPassportSessionService.getPassportSession(anyString()))
+                .thenReturn(passportSessionItem);
 
         APIGatewayProxyResponseEvent response =
                 issueCredentialHandler.handleRequest(event, mockContext);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
@@ -13,6 +13,9 @@ public class AuditEvent {
     @JsonProperty("event_name")
     private final AuditEventTypes eventName;
 
+    @JsonProperty("govuk_signin_journey_id")
+    private final String govukSigninJourneyId;
+
     @JsonProperty("component_id")
     private final String componentId;
 
@@ -23,12 +26,14 @@ public class AuditEvent {
     @JsonCreator
     public AuditEvent(
             @JsonProperty(value = "event_name", required = true) AuditEventTypes eventName,
+            @JsonProperty(value = "govuk_signin_journey_id") String govukSigninJourneyId,
             @JsonProperty(value = "component_id") String componentId,
             @JsonProperty(value = "user") AuditEventUser user,
             @JsonProperty(value = "restricted") AuditRestricted restricted,
             @JsonProperty(value = "extensions") AuditExtensions extensions) {
         this.timestamp = Instant.now().getEpochSecond();
         this.eventName = eventName;
+        this.govukSigninJourneyId = govukSigninJourneyId;
         this.componentId = componentId;
         this.user = user;
         this.restricted = restricted;
@@ -41,6 +46,10 @@ public class AuditEvent {
 
     public AuditEventTypes getEventName() {
         return eventName;
+    }
+
+    public String getGovukSigninJourneyId() {
+        return govukSigninJourneyId;
     }
 
     public String getComponentId() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/LogHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.passport.library.helpers;
 
+import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
@@ -16,6 +17,7 @@ public class LogHelper {
         ERROR_CODE_LOG_FIELD("errorCode"),
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
         PASSPORT_SESSION_ID_LOG_FIELD("passportSessionId"),
+        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id"),
         JTI_LOG_FIELD("jti"),
         USED_AT_DATE_TIME_LOG_FIELD("usedAtDateTime");
 
@@ -44,6 +46,14 @@ public class LogHelper {
 
     public static void attachPassportSessionIdToLogs(String sessionId) {
         attachFieldToLogs(LogField.PASSPORT_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {
+        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+            attachFieldToLogs(LogField.GOVUK_SIGNIN_JOURNEY_ID, "unknown");
+        } else {
+            attachFieldToLogs(LogField.GOVUK_SIGNIN_JOURNEY_ID, govukSigninJourneyId);
+        }
     }
 
     public static void logOauthError(String message, String errorCode, String errorDescription) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/persistence/item/PassportSessionItem.java
@@ -12,6 +12,7 @@ public class PassportSessionItem implements DynamodbItem {
     private String creationDateTime;
     private String latestDcsResponseResourceId;
     private String userId;
+    private String govukSigninJourneyId;
     private int attemptCount;
     private AuthParams authParams;
     private long ttl;
@@ -47,6 +48,14 @@ public class PassportSessionItem implements DynamodbItem {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public String getGovukSigninJourneyId() {
+        return govukSigninJourneyId;
+    }
+
+    public void setGovukSigninJourneyId(String govukSigninJourneyId) {
+        this.govukSigninJourneyId = govukSigninJourneyId;
     }
 
     public int getAttemptCount() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
@@ -27,8 +27,9 @@ public class AuditService {
         return AmazonSQSClientBuilder.defaultClient();
     }
 
-    public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {
-        sendAuditEvent(new AuditEvent(eventType, null, null, null, null));
+    public void sendAuditEvent(AuditEventTypes eventType, String govukSigninJourneyId)
+            throws SqsException {
+        sendAuditEvent(new AuditEvent(eventType, govukSigninJourneyId, null, null, null, null));
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
@@ -19,6 +19,7 @@ public class PassportSessionService {
     private static final String CLIENT_ID = "client_id";
     private static final String STATE = "state";
     private static final String REDIRECT_URI = "redirect_uri";
+    private static final String GOVUK_SIGNIN_JOURNEY_ID = "govuk_signin_journey_id";
 
     private final DataStore<PassportSessionItem> dataStore;
     private final ConfigurationService configurationService;
@@ -55,6 +56,10 @@ public class PassportSessionService {
         passportSessionItem.setCreationDateTime(Instant.now().toString());
         passportSessionItem.setAttemptCount(0);
         passportSessionItem.setUserId(jwtClaimsSet.getSubject());
+
+        String govukSigninJourneyId = jwtClaimsSet.getStringClaim(GOVUK_SIGNIN_JOURNEY_ID);
+        passportSessionItem.setGovukSigninJourneyId(govukSigninJourneyId);
+        LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
         AuthParams authParams =
                 new AuthParams(

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/AuditServiceTest.java
@@ -39,7 +39,7 @@ class AuditServiceTest {
 
     @Test
     void shouldSendMessageToSqsQueue() throws JsonProcessingException, SqsException {
-        auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT);
+        auditService.sendAuditEvent(AuditEventTypes.IPV_PASSPORT_CRI_REQUEST_SENT, "test-id");
 
         ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
                 ArgumentCaptor.forClass(SendMessageRequest.class);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Store the govuk_signin_journey_id claim from the JAR within the back-end session dynamo table.

Use this value and attach it to all of our application logs as well as including it within our audit events to TxMA.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Help with tracking user journeys through our application logs and TxMA audit events.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1759](https://govukverify.atlassian.net/browse/PYI-1759)

