### PR TITLE
PYIC-1791: Move govuk_signin_journey_id into audit event users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ ext {
 		gson:'2.8.9',
 		jackson:'2.13.1',
 		log4j:'2.17.1',
+		lombok:'1.18.22',
 		nimbusJoseJwt:'9.16',
 		nimbusdsOauth2OidcSdk:'9.22.1',
 		powertoolsLogging:'1.12.2',

--- a/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
+++ b/lambdas/checkpassport/src/test/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandlerTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.cri.passport.library.config.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
@@ -132,7 +133,9 @@ class CheckPassportHandlerTest {
 
         verify(auditService)
                 .sendAuditEvent(
-                        AuditEventTypes.IPV_PASSPORT_CRI_END, "test-govuk-signin-journey-id");
+                        AuditEventTypes.IPV_PASSPORT_CRI_END,
+                        new AuditEventUser(
+                                "test-user-id", "test-session-id", "test-govuk-signin-journey-id"));
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
@@ -370,6 +373,7 @@ class CheckPassportHandlerTest {
         PassportSessionItem passportSessionItem = new PassportSessionItem();
         passportSessionItem.setAttemptCount(attemptCount);
         passportSessionItem.setUserId("test-user-id");
+        passportSessionItem.setPassportSessionId("test-session-id");
         passportSessionItem.setGovukSigninJourneyId("test-govuk-signin-journey-id");
         passportSessionItem.setAuthParams(
                 new AuthParams("code", "12345", "read", "https://example.com"));

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 			"org.mockito:mockito-core:4.2.0",
 			"org.mockito:mockito-junit-jupiter:4.2.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.2.0"
+
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 }
 
 java {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEvent.java
@@ -1,13 +1,10 @@
 package uk.gov.di.ipv.cri.passport.library.auditing;
 
-import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.time.Instant;
-
-import static uk.gov.di.ipv.cri.passport.library.helpers.LogHelper.GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
 
 @ExcludeFromGeneratedCoverageReport
 public class AuditEvent {
@@ -15,9 +12,6 @@ public class AuditEvent {
 
     @JsonProperty("event_name")
     private final AuditEventTypes eventName;
-
-    @JsonProperty("govuk_signin_journey_id")
-    private final String govukSigninJourneyId;
 
     @JsonProperty("component_id")
     private final String componentId;
@@ -29,18 +23,12 @@ public class AuditEvent {
     @JsonCreator
     public AuditEvent(
             @JsonProperty(value = "event_name", required = true) AuditEventTypes eventName,
-            @JsonProperty(value = "govuk_signin_journey_id") String govukSigninJourneyId,
             @JsonProperty(value = "component_id") String componentId,
             @JsonProperty(value = "user") AuditEventUser user,
             @JsonProperty(value = "restricted") AuditRestricted restricted,
             @JsonProperty(value = "extensions") AuditExtensions extensions) {
         this.timestamp = Instant.now().getEpochSecond();
         this.eventName = eventName;
-        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
-            this.govukSigninJourneyId = GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
-        } else {
-            this.govukSigninJourneyId = govukSigninJourneyId;
-        }
         this.componentId = componentId;
         this.user = user;
         this.restricted = restricted;
@@ -53,10 +41,6 @@ public class AuditEvent {
 
     public AuditEventTypes getEventName() {
         return eventName;
-    }
-
-    public String getGovukSigninJourneyId() {
-        return govukSigninJourneyId;
     }
 
     public String getComponentId() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventUser.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/auditing/AuditEventUser.java
@@ -1,9 +1,12 @@
 package uk.gov.di.ipv.cri.passport.library.auditing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.passport.library.persistence.item.PassportSessionItem;
 
 @ExcludeFromGeneratedCoverageReport
+@Data
 public class AuditEventUser {
 
     @JsonProperty(value = "user_id")
@@ -12,10 +15,22 @@ public class AuditEventUser {
     @JsonProperty(value = "session_id")
     private final String sessionId;
 
+    @JsonProperty(value = "govuk_signin_journey_id")
+    private final String govukSigninJourneyId;
+
     public AuditEventUser(
             @JsonProperty(value = "user_id") String userId,
-            @JsonProperty(value = "session_id") String sessionId) {
+            @JsonProperty(value = "session_id") String sessionId,
+            @JsonProperty(value = "govuk_signin_journey_id") String govukSigninJourneyId) {
         this.userId = userId;
         this.sessionId = sessionId;
+        this.govukSigninJourneyId = govukSigninJourneyId;
+    }
+
+    public static AuditEventUser fromPassportSessionItem(PassportSessionItem passportSessionItem) {
+        return new AuditEventUser(
+                passportSessionItem.getUserId(),
+                passportSessionItem.getPassportSessionId(),
+                passportSessionItem.getGovukSigninJourneyId());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/AuditService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.cri.passport.library.config.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.exceptions.SqsException;
 
@@ -27,9 +28,12 @@ public class AuditService {
         return AmazonSQSClientBuilder.defaultClient();
     }
 
-    public void sendAuditEvent(AuditEventTypes eventType, String govukSigninJourneyId)
-            throws SqsException {
-        sendAuditEvent(new AuditEvent(eventType, govukSigninJourneyId, null, null, null, null));
+    public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {
+        sendAuditEvent(new AuditEvent(eventType, null, null, null, null));
+    }
+
+    public void sendAuditEvent(AuditEventTypes eventType, AuditEventUser user) throws SqsException {
+        sendAuditEvent(new AuditEvent(eventType, null, user, null, null));
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionService.java
@@ -47,7 +47,8 @@ public class PassportSessionService {
         return dataStore.getItem(passportSessionId);
     }
 
-    public String generatePassportSession(JWTClaimsSet jwtClaimsSet) throws ParseException {
+    public PassportSessionItem generatePassportSession(JWTClaimsSet jwtClaimsSet)
+            throws ParseException {
         PassportSessionItem passportSessionItem = new PassportSessionItem();
         passportSessionItem.setPassportSessionId(SecureTokenHelper.generate());
 
@@ -72,7 +73,7 @@ public class PassportSessionService {
 
         dataStore.create(passportSessionItem);
 
-        return passportSessionItem.getPassportSessionId();
+        return passportSessionItem;
     }
 
     public void setLatestDcsResponseResourceId(String passportSessionID, String resourceId) {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportSessionServiceTest.java
@@ -60,7 +60,7 @@ class PassportSessionServiceTest {
                         .claim("client_id", "ipv-core")
                         .build();
 
-        String passportSessionID = underTest.generatePassportSession(jwtClaimsSet);
+        PassportSessionItem passportSessionItem = underTest.generatePassportSession(jwtClaimsSet);
 
         ArgumentCaptor<PassportSessionItem> passportSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(PassportSessionItem.class);
@@ -68,7 +68,7 @@ class PassportSessionServiceTest {
         assertNotNull(passportSessionItemArgumentCaptor.getValue().getCreationDateTime());
         assertEquals(
                 passportSessionItemArgumentCaptor.getValue().getPassportSessionId(),
-                passportSessionID);
+                passportSessionItem.getPassportSessionId());
     }
 
     @Test

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Move govuk_signin_journey_id into audit event users

### Why did it change

We were logging the govuk journey ID at the top level of the Audit
Events. They need to be nested in the user sub object.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-1791](https://govukverify.atlassian.net/browse/PYI-1791)
