### PR TITLE
PYIC-1715 seperated out aws roles for integration tests vs pipeline deployment

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Set up SAM cli
         uses: aws-actions/setup-sam@v1
 
-      - name: Set up AWS creds
+      - name: Set up AWS creds For Integration Tests
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Integration tests
@@ -53,6 +53,12 @@ jobs:
           JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
           ENVIRONMENT: build
         run: ./gradlew intTest
+
+      - name: Set up AWS creds For Pipeline
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
 
       - name: Generate code signing config
         id: signing


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYIC-1715 seperated out aws roles for integration tests vs pipeline deployment
<!-- Describe the changes in detail - the "what"-->

### Why did it change
PYIC-1715 seperated out aws roles for integration tests vs pipeline deployment
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1715](https://govukverify.atlassian.net/browse/PYIC-1715)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
