### PR TITLE
LIME-130 Add common lib submodule to passport back

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "di-ipv-cri-lib"]
+	path = common-lib
+	url = git@github.com:alphagov/di-ipv-cri-lib.git


### PR DESCRIPTION
## Proposed changes

### What changed

Added di-ipv-cri-lib (common-lib) to Passport Back.

### Why did it change

Preparatory step needed to allow using common-lib.
As of this commit the submodule pointer is at the merged commit of PR48.
Gradle builds are not changed, this is to be done later when passport back has a dependency on it.

### Issue tracking

- [LIME-130](https://govukverify.atlassian.net/browse/LIME-130)
- [LIME-109](https://govukverify.atlassian.net/browse/LIME-109)