### PR TITLE
LIME-131 Rename GatewayId exports to match dns and front.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1119,7 +1119,7 @@ Outputs:
     Description: CRI UK Passport API Gateway ID
     Value: !Sub "${PublicUKPassportAPI}"
     Export:
-      Name: !Sub ${AWS::StackName}-PublicUKPassportAPIGatewayID
+      Name: !Sub PassportBackAPIGatewayID-${AWS::StackName}
 
   PublicUKPassportApiBaseUrl:
     Description: "Base url of the Public UK Passport API Gateway"
@@ -1131,7 +1131,7 @@ Outputs:
     Description: CRI UK Passport Private API Gateway ID
     Value: !Sub "${PrivateUKPassportAPI}"
     Export:
-      Name: !Sub ${AWS::StackName}-PrivateUKPassportAPIGatewayID
+      Name: !Sub IPVCriUkPassportPrivateAPIGatewayID-${AWS::StackName}
 
   PrivateUKPassportApiBaseUrl:
     Description: "Base url of the Private UK Passport API Gateway"


### PR DESCRIPTION
## Proposed changes

### What changed

Renamed GatewayId export names.

### Why did it change

Aligning with expected names in deployed support stacks.

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)

