### PR TITLE
LIME-131 Disable LinkUsagePlanApiKey1 export

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1151,6 +1151,6 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-PrivateUKPassportApiBaseUrl
 
-  IpvCoreBackApiKeyId:
-    Description: The key id of the api key used by IPV Core to access passport back external api gateway
-    Value: !Ref LinkUsagePlanApiKey1
+#  IpvCoreBackApiKeyId:
+#    Description: The key id of the api key used by IPV Core to access passport back external api gateway
+#    Value: !Ref LinkUsagePlanApiKey1


### PR DESCRIPTION
## Proposed changes

### What changed

Disable LinkUsagePlanApiKey1 export

### Why did it change

Key was disabled in the previous commit.

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)