### PR TITLE
LIME-131 Export environment name coupled APIGatewayID names, when in …

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1143,7 +1143,11 @@ Outputs:
     Description: CRI UK Passport API Gateway ID
     Value: !Sub "${PublicUKPassportAPI}"
     Export:
-      Name: !Sub PassportBackAPIGatewayID-${AWS::StackName}
+      Name:
+        !If
+        - IsNotDevEnvironment
+        - !Sub PassportBackAPIGatewayID-${Environment}
+        - !Sub ${AWS::StackName}-PublicUKPassportAPIGatewayID
 
   PublicUKPassportApiBaseUrl:
     Description: "Base url of the Public UK Passport API Gateway"
@@ -1155,7 +1159,11 @@ Outputs:
     Description: CRI UK Passport Private API Gateway ID
     Value: !Sub "${PrivateUKPassportAPI}"
     Export:
-      Name: !Sub IPVCriUkPassportPrivateAPIGatewayID-${AWS::StackName}
+      Name:
+        !If
+        - IsNotDevEnvironment
+        - !Sub IPVCriUkPassportPrivateAPIGatewayID-${Environment}
+        - !Sub ${AWS::StackName}-PrivateUKPassportAPIGatewayID
 
   PrivateUKPassportApiBaseUrl:
     Description: "Base url of the Private UK Passport API Gateway"


### PR DESCRIPTION
## Proposed changes

### What changed

When in non dev environment, tie the APIGatewayID names with environment name.

### Why did it change

DNS stack expects an export with environment name, but dev requires unique export names to allow multiple concurrent but independent stacks.

### Issue tracking
- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)