### PR TITLE
LIME-131 Disable Integration tests until stack for the test is deployed.

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -49,14 +49,13 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
-
-      - name: Integration tests
-        env:
-          DCS_RESPONSE_TABLE_NAME: dcs-response-build
-          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
-          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
-          ENVIRONMENT: build
-        run: ./gradlew intTest
+#      - name: Integration tests
+#        env:
+#          DCS_RESPONSE_TABLE_NAME: dcs-response-build
+#          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
+#          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+#          ENVIRONMENT: build
+#        run: ./gradlew intTest
 
       - name: Perform Static Analysis
         env:


### PR DESCRIPTION
## Proposed changes

### What changed

Disable Integration tests.

### Why did it change

The stack being deployed is the expected stack for the tests.
Disabling test until it is deployed.

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)