### PR TITLE
LIME-131 Disable Integration tests (post merge)

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Build and unit tests
         run: ./gradlew clean build
 
-      - name: Set up AWS creds for integration tests
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
-          aws-region: eu-west-2
+#      - name: Set up AWS creds for integration tests
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
+#          aws-region: eu-west-2
 #      - name: Integration tests
 #        env:
 #          DCS_RESPONSE_TABLE_NAME: dcs-response-build

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -40,19 +40,19 @@ jobs:
       - name: Set up SAM cli
         uses: aws-actions/setup-sam@v1
 
-      - name: Set up AWS creds For Integration Tests
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
-          aws-region: eu-west-2
+#      - name: Set up AWS creds For Integration Tests
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
+#          aws-region: eu-west-2
 
-      - name: Integration tests
-        env:
-          DCS_RESPONSE_TABLE_NAME: dcs-response-build
-          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
-          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
-          ENVIRONMENT: build
-        run: ./gradlew intTest
+#      - name: Integration tests
+#        env:
+#          DCS_RESPONSE_TABLE_NAME: dcs-response-build
+#          JAR_ENCRYPTION_KEY_ID_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionKeyId
+#          JAR_KMS_PUBLIC_KEY_PARAM: /build/credentialIssuers/ukPassport/self/jarKmsEncryptionPublicKey
+#          ENVIRONMENT: build
+#        run: ./gradlew intTest
 
       - name: Set up AWS creds For Pipeline
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Proposed changes

### What changed

Disable Integration tests (post-merge)

### Why did it change

The stack being deployed is the expected stack for the tests.
Disabling test until it is deployed.

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)