### PR TITLE
LIME-131 Disable api-gateway log groups to overcome re-deployment issue

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -134,13 +134,13 @@ Resources:
           "responseLatency":"$context.responseLatency",
           "responseLength":"$context.responseLength"
           }
-
-  IPVCriUKPassportPrivateAPILogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-PassportBackPrivate-API-GW-AccessLogs
-      RetentionInDays: 14
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+# Disabled to overcome re-deployment issue
+#  IPVCriUKPassportPrivateAPILogGroup:
+#    Type: AWS::Logs::LogGroup
+#    Properties:
+#      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-PassportBackPrivate-API-GW-AccessLogs
+#      RetentionInDays: 14
+#      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   IPVCriUKPassportPrivateAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -176,13 +176,13 @@ Resources:
           "responseLatency":"$context.responseLatency",
           "responseLength":"$context.responseLength"
           }
-
-  IPVCriUKPassportAPILogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CriPassport-API-GW-AccessLogs
-      RetentionInDays: 14
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+# Disabled to overcome re-deployment issue
+#  IPVCriUKPassportAPILogGroup:
+#    Type: AWS::Logs::LogGroup
+#    Properties:
+#      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CriPassport-API-GW-AccessLogs
+#      RetentionInDays: 14
+#      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   IPVCriUKPassportAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Disabled api-gateway log groups

### Why did it change

Pipeline is failing on re-creation of log-groups. 

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)