### PR TITLE
LIME-189 Capture PassportCRI Metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
 		nimbusJoseJwt:'9.16',
 		nimbusdsOauth2OidcSdk:'9.22.1',
 		powertoolsLogging:'1.12.2',
+		powertoolsMetrics:'1.12.2',
 		powertoolsParameters:'1.9.0',
 		cri_common_lib: "1.1.7"
 	]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,6 +8,8 @@ Globals:
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        POWERTOOLS_LOG_LEVEL: INFO
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
     CodeSigningConfigArn: !If
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
@@ -43,6 +45,10 @@ Parameters:
     Description: >
       The ARN of the permissions boundary to apply to any role created by the template
     Default: "none"
+# When common stack support is added CriIdentifier should be pointed to passport SSM Param /common-cri-parameters/CriIdentifier
+  CriIdentifier:
+    Type: String
+    Default: "di-ipv-cri-uk-passport-api"
 
 Mappings:
   EnvironmentConfiguration:
@@ -234,6 +240,7 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
           ENVIRONMENT: !Sub "${Environment}"
           DCS_RESPONSE_TABLE_NAME: !Select [1, !Split ['/', !GetAtt DCSResponseTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
@@ -321,6 +328,7 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-accesstoken"
           ENVIRONMENT: !Sub "${Environment}"
           CRI_PASSPORT_AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAuthCodesTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
@@ -398,6 +406,7 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-checkpassport"
           ENVIRONMENT: !Sub "${Environment}"
           DCS_RESPONSE_TABLE_NAME: !Select [1, !Split ['/', !GetAtt DCSResponseTable.Arn]]
           CRI_PASSPORT_ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt CRIPassportAccessTokensTable.Arn]]
@@ -479,6 +488,7 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-buildclientoauthresponse"
           ENVIRONMENT: !Sub "${Environment}"
           CRI_PASSPORT_AUTH_CODES_TABLE_NAME: !Ref CRIPassportAuthCodesTable
           PASSPORT_BACK_SESSIONS_TABLE_NAME: !Ref CRIPassportBackSessionsTable
@@ -548,6 +558,7 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-initialisesession"
           ENVIRONMENT: !Sub "${Environment}"
           PASSPORT_BACK_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt CRIPassportBackSessionsTable.Arn ] ]
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/credentialIssuers/ukPassport/clients"

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -22,11 +22,12 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib"),
 			configurations.cri_common_lib
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/cri/passport/accesstoken/AccessTokenHandlerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.accesstoken.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.cri.passport.accesstoken.validation.TokenRequestValidator;
 import uk.gov.di.ipv.cri.passport.library.domain.AuthParams;
@@ -43,6 +44,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_ACCESS_TOKEN_COMPLETED_OK;
 
 @ExtendWith(MockitoExtension.class)
 class AccessTokenHandlerTest {
@@ -62,6 +65,7 @@ class AccessTokenHandlerTest {
     @Mock private AuthorizationCodeService mockAuthorizationCodeService;
     @Mock private PassportSessionService mockPassportSessionService;
     @Mock private TokenRequestValidator mockTokenRequestValidator;
+    @Mock private EventProbe mockEventProbe;
     @InjectMocks private AccessTokenHandler handler;
 
     @Test
@@ -82,6 +86,8 @@ class AccessTokenHandlerTest {
         mockSessionItem();
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_OK);
 
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
@@ -121,6 +127,8 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_OK);
+
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         assertEquals(200, response.getStatusCode());
@@ -136,6 +144,8 @@ class AccessTokenHandlerTest {
         event.setBody(invalidTokenRequest);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
@@ -158,6 +168,8 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
+
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
@@ -178,6 +190,8 @@ class AccessTokenHandlerTest {
         event.setBody(tokenRequestBody);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
@@ -201,6 +215,8 @@ class AccessTokenHandlerTest {
         when(mockAuthorizationCodeService.getAuthCodeItem("12345")).thenReturn(null);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
@@ -229,6 +245,8 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
+
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
@@ -249,6 +267,8 @@ class AccessTokenHandlerTest {
         when(mockAccessTokenService.validateAuthorizationGrant(any()))
                 .thenReturn(ValidationResult.createValidResult());
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
@@ -279,6 +299,9 @@ class AccessTokenHandlerTest {
                 .authenticateClient(any());
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
+
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
         assertEquals(HTTPResponse.SC_UNAUTHORIZED, response.getStatusCode());
@@ -316,6 +339,8 @@ class AccessTokenHandlerTest {
                 .thenReturn(passportSessionItem);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         verify(mockAccessTokenService)
                 .revokeAccessToken(authorizationCodeItem.getIssuedAccessToken());
@@ -362,6 +387,8 @@ class AccessTokenHandlerTest {
                 .thenReturn(passportSessionItem);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR);
 
         verify(mockAccessTokenService)
                 .revokeAccessToken(authorizationCodeItem.getIssuedAccessToken());

--- a/lambdas/buildclientoauthresponse/build.gradle
+++ b/lambdas/buildclientoauthresponse/build.gradle
@@ -15,11 +15,12 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib"),
 			configurations.cri_common_lib
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/checkpassport/build.gradle
+++ b/lambdas/checkpassport/build.gradle
@@ -23,11 +23,12 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib"),
 			configurations.cri_common_lib
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
@@ -16,7 +16,10 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEvent;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
@@ -62,6 +65,15 @@ import java.util.UUID;
 
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.MAXIMUM_ATTEMPT_COUNT;
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.VERIFIABLE_CREDENTIAL_ISSUER;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DCS_CHECK_REQUEST_FAILED;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DCS_CHECK_REQUEST_SUCCEEDED;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_FAIL;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.FORM_DATA_PARSE_PASS;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_CHECK_PASSPORT_COMPLETED_OK;
 
 public class CheckPassportHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -88,25 +100,29 @@ public class CheckPassportHandler
     private final AuditService auditService;
 
     private final PassportSessionService passportSessionService;
+    private final EventProbe eventProbe;
 
     public CheckPassportHandler(
             PassportService passportService,
             ConfigurationService configurationService,
             DcsCryptographyService dcsCryptographyService,
             AuditService auditService,
-            PassportSessionService passportSessionService) {
+            PassportSessionService passportSessionService,
+            EventProbe eventProbe) {
         this.passportService = passportService;
         this.configurationService = configurationService;
         this.dcsCryptographyService = dcsCryptographyService;
         this.auditService = auditService;
         this.passportSessionService = passportSessionService;
+        this.eventProbe = eventProbe;
     }
 
     public CheckPassportHandler()
             throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
                     KeyStoreException, IOException {
+        this.eventProbe = new EventProbe();
         this.configurationService = new ConfigurationService();
-        this.passportService = new PassportService(configurationService);
+        this.passportService = new PassportService(configurationService, eventProbe);
         this.dcsCryptographyService = new DcsCryptographyService(configurationService);
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
@@ -114,7 +130,8 @@ public class CheckPassportHandler
     }
 
     @Override
-    @Logging(clearState = true)
+    @Logging(clearState = true, correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
+    @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
@@ -125,6 +142,7 @@ public class CheckPassportHandler
                     passportSessionService.getPassportSession(passportSessionId);
 
             if (passportSessionItem == null) {
+                eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatus.SC_BAD_REQUEST,
                         new ErrorObject(
@@ -147,6 +165,8 @@ public class CheckPassportHandler
             LogHelper.attachClientIdToLogs(authorizationRequest.getClientID().getValue());
 
             DcsPayload dcsPayload = parsePassportFormRequest(input.getBody());
+            eventProbe.counterMetric(FORM_DATA_PARSE_PASS);
+
             JWSObject preparedDcsPayload = preparePayload(dcsPayload);
 
             auditService.sendAuditEvent(
@@ -156,6 +176,7 @@ public class CheckPassportHandler
                             authorizationRequest.getClientID().getValue()));
 
             DcsSignedEncryptedResponse dcsResponse = doPassportCheck(preparedDcsPayload);
+            eventProbe.counterMetric(DCS_CHECK_REQUEST_SUCCEEDED);
 
             AuditEventUser auditEventUser =
                     AuditEventUser.fromPassportSessionItem(passportSessionItem);
@@ -179,18 +200,24 @@ public class CheckPassportHandler
             passportSessionService.setLatestDcsResponseResourceId(
                     passportSessionId, passportCheckDao.getResourceId());
 
+            // Lambda Complete No Error
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_OK);
+
             return validateResponseAndAttemptCount(passportSessionId, unwrappedDcsResponse);
 
         } catch (OAuthHttpResponseExceptionWithErrorBody e) {
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getStatusCode(),
                     new ErrorObject(OAuth2Error.SERVER_ERROR_CODE, e.getErrorReason())
                             .toJSONObject());
         } catch (HttpResponseExceptionWithErrorBody e) {
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getStatusCode(), e.getErrorResponse());
         } catch (ParseException e) {
             LOGGER.error("Authentication request could not be parsed", e);
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     new ErrorObject(
@@ -200,6 +227,7 @@ public class CheckPassportHandler
                             .toJSONObject());
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     new ErrorObject(
@@ -216,14 +244,21 @@ public class CheckPassportHandler
         int attemptCount =
                 passportSessionService.getPassportSession(passportSessionId).getAttemptCount();
 
-        if (unwrappedDcsResponse.isValid()
-                || attemptCount
-                        >= Integer.parseInt(
-                                configurationService.getSsmParameter(MAXIMUM_ATTEMPT_COUNT))) {
+        if (unwrappedDcsResponse.isValid()) {
+            eventProbe.counterMetric(
+                    LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX + attemptCount);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_OK, Map.of(RESULT, RESULT_FINISH));
         }
 
+        if (attemptCount
+                >= Integer.parseInt(configurationService.getSsmParameter(MAXIMUM_ATTEMPT_COUNT))) {
+            eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_OK, Map.of(RESULT, RESULT_FINISH));
+        }
+
+        eventProbe.counterMetric(LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY);
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 HttpStatus.SC_OK, Map.of(RESULT, RESULT_RETRY));
     }
@@ -286,6 +321,7 @@ public class CheckPassportHandler
             return objectMapper.readValue(input, DcsPayload.class);
         } catch (JsonProcessingException e) {
             LOGGER.error(("Failed to parse payload from input: " + e.getMessage()));
+            eventProbe.counterMetric(FORM_DATA_PARSE_FAIL);
             throw new OAuthHttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_PASSPORT_FORM_DATA);
         }
@@ -315,6 +351,7 @@ public class CheckPassportHandler
             return passportService.dcsPassportCheck(preparedPayload);
         } catch (IOException | EmptyDcsResponseException e) {
             LOGGER.error(("Passport check with DCS failed: " + e.getMessage()));
+            eventProbe.counterMetric(DCS_CHECK_REQUEST_FAILED);
             throw new OAuthHttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.ERROR_CONTACTING_DCS);
         }

--- a/lambdas/initialisesession/build.gradle
+++ b/lambdas/initialisesession/build.gradle
@@ -22,7 +22,9 @@ dependencies {
 			project(":lib"),
 			configurations.cri_common_lib
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
 			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",

--- a/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
+++ b/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
@@ -11,7 +11,10 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
@@ -34,6 +37,8 @@ import uk.gov.di.ipv.cri.passport.library.validation.JarValidator;
 import java.text.ParseException;
 
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.JAR_ENCRYPTION_KEY_ID;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_INITIALISE_SESSION_COMPLETED_OK;
 
 public class InitialiseSessionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -50,17 +55,21 @@ public class InitialiseSessionHandler
     private static final String CLIENT_ID = "client_id";
     private static final String SHARED_CLAIMS = "shared_claims";
 
+    private final EventProbe eventProbe;
+
     public InitialiseSessionHandler(
             ConfigurationService configurationService,
             KmsRsaDecrypter kmsRsaDecrypter,
             JarValidator jarValidator,
             AuditService auditService,
-            PassportSessionService passportSessionService) {
+            PassportSessionService passportSessionService,
+            EventProbe eventProbe) {
         this.configurationService = configurationService;
         this.kmsRsaDecrypter = kmsRsaDecrypter;
         this.jarValidator = jarValidator;
         this.auditService = auditService;
         this.passportSessionService = passportSessionService;
+        this.eventProbe = eventProbe;
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -72,10 +81,12 @@ public class InitialiseSessionHandler
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
         this.passportSessionService = new PassportSessionService(configurationService);
+        eventProbe = new EventProbe();
     }
 
     @Override
-    @Logging(clearState = true)
+    @Logging(clearState = true, correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
+    @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
@@ -83,12 +94,14 @@ public class InitialiseSessionHandler
             String clientId = RequestHelper.getHeaderByKey(input.getHeaders(), CLIENT_ID);
 
             if (StringUtils.isBlank(clientId)) {
+                eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         BAD_REQUEST, ErrorResponse.MISSING_CLIENT_ID_QUERY_PARAMETER);
             }
             LogHelper.attachClientIdToLogs(clientId);
 
             if (input.getBody() == null) {
+                eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         BAD_REQUEST, ErrorResponse.MISSING_SHARED_ATTRIBUTES_JWT);
             }
@@ -107,24 +120,30 @@ public class InitialiseSessionHandler
             JarResponse response =
                     generateJarResponse(claimsSet, passportSessionItem.getPassportSessionId());
 
+            eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_OK);
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(OK, response);
         } catch (RecoverableJarValidationException e) {
             LOGGER.error("JAR validation failed: {}", e.getErrorObject().getDescription());
             RedirectErrorResponse errorResponse =
                     new RedirectErrorResponse(
                             e.getRedirectUri(), e.getState(), e.getErrorObject().toJSONObject());
+            eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), errorResponse);
         } catch (JarValidationException e) {
             LOGGER.error("JAR validation failed: {}", e.getErrorObject().getDescription());
+            eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());
         } catch (ParseException e) {
             LOGGER.error("Failed to parse claim set when attempting to retrieve JAR claims");
+            eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE);
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
+            eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE);

--- a/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
+++ b/lambdas/initialisesession/src/test/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.cri.passport.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.cri.passport.library.error.ErrorResponse;
@@ -55,6 +56,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
 import static uk.gov.di.ipv.cri.passport.library.helpers.fixtures.TestFixtures.JWE_OBJECT_STRING;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.LAMBDA_INITIALISE_SESSION_COMPLETED_OK;
 
 @ExtendWith(MockitoExtension.class)
 class InitialiseSessionHandlerTest {
@@ -74,6 +77,8 @@ class InitialiseSessionHandlerTest {
     private SignedJWT signedJWT;
 
     @Mock Context context;
+
+    @Mock private EventProbe mockEventProbe;
 
     @BeforeEach
     void setUp() throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
@@ -118,6 +123,9 @@ class InitialiseSessionHandlerTest {
         event.setBody(JWE_OBJECT_STRING);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_OK);
+
         assertEquals(200, response.getStatusCode());
         verify(auditService)
                 .sendAuditEvent(
@@ -139,6 +147,8 @@ class InitialiseSessionHandlerTest {
 
         var response = underTest.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_OK);
+
         Map<String, Object> claims =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
@@ -158,6 +168,8 @@ class InitialiseSessionHandlerTest {
         event.setBody(null);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
 
         Map<String, Object> error =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
@@ -181,6 +193,8 @@ class InitialiseSessionHandlerTest {
         event.setBody(JWE_OBJECT_STRING);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
 
         Map<String, Object> error =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
@@ -206,6 +220,8 @@ class InitialiseSessionHandlerTest {
 
         var response = underTest.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
+
         Map<String, Object> error =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
         assertEquals(400, response.getStatusCode());
@@ -221,6 +237,8 @@ class InitialiseSessionHandlerTest {
         event.setHeaders(noClientId);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
 
         Map<String, Object> error =
                 OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
@@ -241,6 +259,8 @@ class InitialiseSessionHandlerTest {
         event.setBody(JWE_OBJECT_STRING);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
 
@@ -267,6 +287,8 @@ class InitialiseSessionHandlerTest {
 
         var response = underTest.handleRequest(event, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
+
         assertEquals(302, response.getStatusCode());
         assertEquals(
                 "{\"redirect_uri\":\"http://redirect-url.com\",\"oauth_error\":{\"error_description\":\"Invalid request JWT\",\"error\":\"invalid_request_object\"}}",
@@ -289,6 +311,8 @@ class InitialiseSessionHandlerTest {
         event.setBody(JWE_OBJECT_STRING);
 
         var response = underTest.handleRequest(event, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR);
 
         assertEquals(302, response.getStatusCode());
         assertEquals(

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -23,11 +23,12 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib"),
 			configurations.cri_common_lib
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging"
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id "java-library"
 	id "idea"
 	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 dependencies {
@@ -21,9 +22,11 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			configurations.cri_common_lib
+
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
 
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.32.0",
 			"org.junit.jupiter:junit-jupiter:5.8.2",

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/metrics/Definitions.java
@@ -1,0 +1,60 @@
+package uk.gov.di.ipv.cri.passport.library.metrics;
+
+public class Definitions {
+
+    // These completed metrics record all escape routes from the lambdas.
+    // OK for expected routes with ERROR being all others
+    public static final String LAMBDA_INITIALISE_SESSION_COMPLETED_OK =
+            "lambda_initialise_session_completed_ok";
+    public static final String LAMBDA_INITIALISE_SESSION_COMPLETED_ERROR =
+            "lambda_initialise_session_completed_error";
+
+    public static final String LAMBDA_CHECK_PASSPORT_COMPLETED_OK =
+            "lambda_check_passport_completed_ok";
+    public static final String LAMBDA_CHECK_PASSPORT_COMPLETED_ERROR =
+            "lambda_check_passport_completed_error";
+
+    public static final String LAMBDA_BUILD_CLIENT_OAUTH_RESPONSE_COMPLETED_OK =
+            "lambda_build_client_oauth_response_completed_ok";
+    public static final String LAMBDA_BUILD_CLIENT_OAUTH_RESPONSE_COMPLETED_ERROR =
+            "lambda_build_client_oauth_response_completed_error";
+
+    public static final String LAMBDA_ACCESS_TOKEN_COMPLETED_OK =
+            "lambda_access_token_completed_ok";
+    public static final String LAMBDA_ACCESS_TOKEN_COMPLETED_ERROR =
+            "lambda_access_token_completed_error";
+
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK =
+            "lambda_issue_credential_completed_ok";
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR =
+            "lambda_issue_credential_completed_error";
+
+    // Document Status after an attempt
+    public static final String LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_VERIFIED_PREFIX =
+            "lambda_check_passport_attempt_status_verified_"; // Attempt count appended
+    public static final String LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_RETRY =
+            "lambda_check_passport_attempt_status_retry";
+    public static final String LAMBDA_CHECK_PASSPORT_ATTEMPT_STATUS_UNVERIFIED =
+            "lambda_check_passport_attempt_status_unverified";
+
+    // FormDataParse
+    public static final String FORM_DATA_PARSE_PASS = "form_data_parse_pass";
+    public static final String FORM_DATA_PARSE_FAIL = "form_data_parse_fail";
+
+    // DCS
+    public static final String DCS_CHECK_REQUEST_SUCCEEDED = "dcs_check_request_succeeded";
+    public static final String DCS_CHECK_REQUEST_FAILED = "dcs_check_request_failed";
+
+    public static final String PASSPORT_CI_PREFIX = "passport_ci_";
+
+    // Third Party Response Type DCS
+    public static final String THIRD_PARTY_DCS_RESPONSE_OK = "third_party_dcs_response_ok";
+    public static final String THIRD_PARTY_DCS_RESPONSE_TYPE_ERROR =
+            "third_party_dcs_response_type_error";
+    public static final String THIRD_PARTY_DCS_RESPONSE_TYPE_EMPTY =
+            "third_party_dcs_response_type_empty";
+
+    private Definitions() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/service/PassportServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.passport.library.config.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsPayload;
 import uk.gov.di.ipv.cri.passport.library.domain.DcsSignedEncryptedResponse;
@@ -47,14 +48,14 @@ class PassportServiceTest {
     @Mock JWSObject jwsObject;
     @Mock HttpResponse httpResponse;
     @Mock StatusLine statusLine;
-
+    @Mock EventProbe eventProbe;
     @Captor ArgumentCaptor<HttpPost> httpPost;
 
     private PassportService underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new PassportService(httpClient, configurationService, dataStore);
+        underTest = new PassportService(httpClient, configurationService, dataStore, eventProbe);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Add AWS Lambda Powertools to Template - namespace/service follows naming conventions used in the other CRIs

Added powertools metrics to aspect section of gradle builds.
Moved existing powertools to aspects section.

Added the following metrics to PassportCRI

All Lambdas - Lambda Completed ok/error

Check Passport Lambda
PermitCheckStatus - Verified, Retry, Unverified
FormDataParse - pass/fail
DCS Check Request - succeeded/failed
DCS Response Type - ok/error/empty

IssueCredential Lambda
Passport Contra Indicators - generated

### Why did it change

Metrics added to cover metrics requested for LIME-189

Definitions located in passport lib ...passport/library/metrics/Definitions.java.

### Issue tracking

- [LIME-189](https://govukverify.atlassian.net/browse/LIME-189)