### PR TITLE
LIME-243: Updating VC expiry to 6 months

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -67,6 +67,23 @@ Mappings:
     production:
       provisionedConcurrency: 1
 
+    MaxVCJwtTtlMapping:
+      Environment:
+        dev: "6"
+        build: "6"
+        staging: "6"
+        integration: "6"
+        production: "2"
+
+    # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
+    JwtTtlUnitMapping:
+      Environment:
+        dev: MONTHS
+        build: MONTHS
+        staging: MONTHS
+        integration: MONTHS
+        production: HOURS
+
 Conditions:
   AddProvisionedConcurrency: !Not
     - !Equals
@@ -260,6 +277,10 @@ Resources:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/verifiableCredentialIssuer
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/maxJwtTtl
+       - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/MaxVCJwtTtlMapping
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/JwtTtlUnit
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/credentialIssuers/ukPassport/self/backendSessionTtl
         - SSMParameterReadPolicy:
@@ -867,6 +888,22 @@ Resources:
                   Value: !Sub "IPV Passport Back Private API Gateway ${Environment}"
             Period: 300
             Stat: Sum
+
+  MaxVCJwtTtlMapping:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub ${Environment}/credentialIssuers/ukPassport/self/MaxVCJwtTtlMapping
+      Type: String
+      Value: !FindInMap [ MaxVCJwtTtlMapping, Environment, !Ref Environment ]
+      Description: default time to live for an JWT in (seconds)
+
+  JwtTtlUnitParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub ${Environment}/credentialIssuers/ukPassport/self/JwtTtlUnit
+      Type: String
+      Value: !FindInMap [ JwtTtlUnitMapping, Environment, !Ref Environment ]
+      Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
 
   ####################################################################
   #                                                                  #

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -51,7 +52,6 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
-import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.MAX_JWT_TTL;
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.VERIFIABLE_CREDENTIAL_ISSUER;
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID;
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VC_CLAIM;
@@ -251,14 +251,9 @@ public class IssueCredentialHandler
                         .issuer(configurationService.getSsmParameter(VERIFIABLE_CREDENTIAL_ISSUER))
                         .audience(configurationService.getClientIssuer(passportCheck.getClientId()))
                         .notBeforeTime(new Date(now.toEpochMilli()))
-                        .expirationTime(
-                                new Date(
-                                        now.plusSeconds(
-                                                        Long.parseLong(
-                                                                configurationService
-                                                                        .getSsmParameter(
-                                                                                MAX_JWT_TTL)))
-                                                .toEpochMilli()))
+                        .claim(
+                                JWTClaimNames.EXPIRATION_TIME,
+                                configurationService.getVcExpiryTime())
                         .claim(VC_CLAIM, verifiableCredential)
                         .build();
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/IssueCredentialHandlerTest.java
@@ -70,7 +70,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.MAX_JWT_TTL;
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.VERIFIABLE_CREDENTIAL_ISSUER;
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.cri.passport.library.domain.verifiablecredential.VerifiableCredentialConstants.VERIFIABLE_CREDENTIAL_TYPE;
@@ -210,7 +209,6 @@ class IssueCredentialHandlerTest {
     private void mockConfigurationServiceCalls() {
         when(mockConfigurationService.getSsmParameter(VERIFIABLE_CREDENTIAL_ISSUER))
                 .thenReturn("TEST");
-        when(mockConfigurationService.getSsmParameter(MAX_JWT_TTL)).thenReturn("1000");
     }
 
     @Test
@@ -236,6 +234,7 @@ class IssueCredentialHandlerTest {
                 .thenReturn("test-issuer");
         when(mockConfigurationService.getClientIssuer(clientId))
                 .thenReturn("https://example.com/issuer");
+        when(mockConfigurationService.getVcExpiryTime()).thenReturn(1000l);
         mockConfigurationServiceCalls();
 
         PassportSessionItem passportSessionItem = new PassportSessionItem();
@@ -256,6 +255,7 @@ class IssueCredentialHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals(6, claimsSet.size());
         assertEquals("https://example.com/issuer", claimsSet.get("aud").asText());
+        assertEquals(claimsSet.get(JWTClaimNames.EXPIRATION_TIME).asText(), "1000");
 
         verify(mockAccessTokenService).revokeAccessToken(accessTokenItem.getAccessToken());
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ConfigurationVariable.java
@@ -14,6 +14,8 @@ public enum ConfigurationVariable {
     MAXIMUM_ATTEMPT_COUNT("/%s/credentialIssuers/ukPassport/self/maximumAttemptCount"),
     PASSPORT_CRI_CLIENT_AUDIENCE("/%s/credentialIssuers/ukPassport/self/audienceForClients"),
     PASSPORT_CRI_CLIENT_AUTH_MAX_TTL("/%s/credentialIssuers/ukPassport/self/maxJwtTtl"),
+    PASSPORT_CRI_CLIENT_VC_MAX_TTL("/%s/credentialIssuers/ukPassport/self/MaxVCJwtTtlMapping"),
+    PASSPORT_CRI_CLIENT_TTL_UNIT("/%s/credentialIssuers/ukPassport/self/JwtTtlUnit"),
     PASSPORT_CRI_ENCRYPTION_KEY(
             "/%s/credentialIssuers/ukPassport/self/encryptionKeyForPassportToDecrypt"),
     PASSPORT_CRI_SIGNING_CERT("/%s/credentialIssuers/ukPassport/self/signingCertForDcsToVerify"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Using some common CRI code to add VC expiry params to the passport CRI and update passport expiry to 6 months in non prod envs

### Why did it change

To allow IPV core to perform identity reuse

