### PR TITLE
LIME-243: Fixed yaml formatting issues

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -892,7 +892,7 @@ Resources:
   MaxVCJwtTtlMapping:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "${Environment}/credentialIssuers/ukPassport/self/MaxVCJwtTtlMapping"
+      Name: !Sub "/${Environment}/credentialIssuers/ukPassport/self/MaxVCJwtTtlMapping"
       Type: String
       Value: !FindInMap [ MaxVCJwtTtlMapping, Environment, !Ref Environment ]
       Description: default time to live for a VC
@@ -900,7 +900,7 @@ Resources:
   JwtTtlUnitParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "${Environment}/credentialIssuers/ukPassport/self/JwtTtlUnit"
+      Name: !Sub "/${Environment}/credentialIssuers/ukPassport/self/JwtTtlUnit"
       Type: String
       Value: !FindInMap [ JwtTtlUnitMapping, Environment, !Ref Environment ]
       Description: The unit for the time-to-live for an JWT e.g. (MONTHS)


### PR DESCRIPTION
## Proposed changes

### What changed

Added slash to the front of the parameter declaration

### Why did it change

Name of the parameter. If the name contains a path (e.g., any forward slashes (/)), it must be fully qualified with a leading forward slash (/). For additional requirements and constraints, see the [AWS SSM User Guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html).

