### PR TITLE
LIME-255 - Updating VC to include issuer code

### DIFF
--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/passport/issuecredential/domain/VerifiableCredentialTest.java
@@ -23,6 +23,7 @@ class VerifiableCredentialTest {
     public static final String PASSPORT_NUMBER = "passportNumber";
     public static final LocalDate DATE_OF_BIRTH = LocalDate.of(1984, 9, 28);
     public static final LocalDate EXPIRY_DATE = LocalDate.of(2034, 9, 28);
+    public static final String ISSUING_COUNTRY_CODE = "GBR";
     public static final String RESOURCE_ID = "resourceId";
 
     @Test
@@ -72,6 +73,13 @@ class VerifiableCredentialTest {
                 EXPIRY_DATE.toString(),
                 verifiableCredential.getCredentialSubject().getPassport().get(0).getExpiryDate());
         assertEquals(
+                ISSUING_COUNTRY_CODE,
+                verifiableCredential
+                        .getCredentialSubject()
+                        .getPassport()
+                        .get(0)
+                        .getIcaoIssuerCode());
+        assertEquals(
                 EVIDENCE_TYPE_IDENTITY_CHECK, verifiableCredential.getEvidence().get(0).getType());
         assertDoesNotThrow(
                 () -> UUID.fromString(verifiableCredential.getEvidence().get(0).getTxn()));
@@ -98,7 +106,8 @@ class VerifiableCredentialTest {
                         + "    } ],\n"
                         + "    \"passport\" : [ {\n"
                         + "      \"documentNumber\" : \"passportNumber\",\n"
-                        + "      \"expiryDate\" : \"2034-09-28\"\n"
+                        + "      \"expiryDate\" : \"2034-09-28\",\n"
+                        + "      \"icaoIssuerCode\" : \"GBR\"\n"
                         + "    } ]\n"
                         + "  },\n"
                         + "  \"evidence\" : [ {\n"
@@ -147,7 +156,8 @@ class VerifiableCredentialTest {
                         + "    } ],\n"
                         + "    \"passport\" : [ {\n"
                         + "      \"documentNumber\" : \"passportNumber\",\n"
-                        + "      \"expiryDate\" : \"2034-09-28\"\n"
+                        + "      \"expiryDate\" : \"2034-09-28\",\n"
+                        + "      \"icaoIssuerCode\" : \"GBR\"\n"
                         + "    } ]\n"
                         + "  },\n"
                         + "  \"evidence\" : [ {\n"

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Passport.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/Passport.java
@@ -5,15 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Passport {
     private String documentNumber;
+    private String icaoIssuerCode;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private String expiryDate;
 
     public Passport(
             @JsonProperty(value = "documentNumber") String documentNumber,
-            @JsonProperty(value = "expiryDate") String expiryDate) {
+            @JsonProperty(value = "expiryDate") String expiryDate,
+            @JsonProperty(value = "icaoIssuerCode") String icaoIssuerCode) {
         this.documentNumber = documentNumber;
         this.expiryDate = expiryDate;
+        this.icaoIssuerCode = icaoIssuerCode;
     }
 
     public String getDocumentNumber() {
@@ -30,5 +33,13 @@ public class Passport {
 
     public void setExpiryDate(String expiryDate) {
         this.expiryDate = expiryDate;
+    }
+
+    public String getIcaoIssuerCode() {
+        return icaoIssuerCode;
+    }
+
+    public void setIcaoIssuerCode(String icaoIssuerCode) {
+        this.icaoIssuerCode = icaoIssuerCode;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/verifiablecredential/VerifiableCredential.java
@@ -52,7 +52,10 @@ public class VerifiableCredential {
                         List.of(
                                 new Passport(
                                         passportCheck.getDcsPayload().getPassportNumber(),
-                                        passportCheck.getDcsPayload().getExpiryDate().toString())));
+                                        passportCheck.getDcsPayload().getExpiryDate().toString(),
+                                        // Country code will need to be updated once users outside
+                                        // of UK can use the service
+                                        "GBR")));
 
         return new VerifiableCredential(
                 credentialSubject, Collections.singletonList(passportCheck.getEvidence()));

--- a/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/passport/library/helpers/JwtHelperTest.java
@@ -45,6 +45,7 @@ class JwtHelperTest {
     public static final String PASSPORT_NUMBER = "123456789";
     public static final String GIVEN_NAME = "Paul";
     public static final String EXPIRY_DATE = "2020-01-01";
+    public static final String ISSUING_COUNTRY_CODE = "GBR";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -66,7 +67,8 @@ class JwtHelperTest {
                                 List.of(
                                         new Passport(
                                                 PASSPORT_NUMBER,
-                                                LocalDate.parse(EXPIRY_DATE).toString()))),
+                                                LocalDate.parse(EXPIRY_DATE).toString(),
+                                                ISSUING_COUNTRY_CODE))),
                         Collections.singletonList(
                                 new Evidence(UUID.randomUUID().toString(), 4, 2, null)));
 


### PR DESCRIPTION
### What changed

Added icaoIssuerCode to passport Verifiable credential

### Why did it change

As per VC spec listed here - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0024-identity-vc-for-checks.md#document-validity-check