### PR TITLE
LIME-399 - Redirect URI fix for associated FE changes.

### DIFF
--- a/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
+++ b/lambdas/initialisesession/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/InitialiseSessionHandler.java
@@ -118,7 +118,10 @@ public class InitialiseSessionHandler
                     AuditEventUser.fromPassportSessionItem(passportSessionItem));
 
             JarResponse response =
-                    generateJarResponse(claimsSet, passportSessionItem.getPassportSessionId());
+                    generateJarResponse(
+                            claimsSet,
+                            passportSessionItem.getPassportSessionId(),
+                            passportSessionItem.getAuthParams().getRedirectUri());
 
             eventProbe.counterMetric(LAMBDA_INITIALISE_SESSION_COMPLETED_OK);
 
@@ -150,8 +153,10 @@ public class InitialiseSessionHandler
         }
     }
 
-    private JarResponse generateJarResponse(JWTClaimsSet claimsSet, String passportSessionId)
+    private JarResponse generateJarResponse(
+            JWTClaimsSet claimsSet, String passportSessionId, String redirectUrl)
             throws ParseException {
-        return new JarResponse(claimsSet.getJSONObjectClaim(SHARED_CLAIMS), passportSessionId);
+        return new JarResponse(
+                claimsSet.getJSONObjectClaim(SHARED_CLAIMS), passportSessionId, redirectUrl);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/JarResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/domain/JarResponse.java
@@ -13,9 +13,14 @@ public class JarResponse {
     @JsonProperty("passportSessionId")
     private String passportSessionId;
 
-    public JarResponse(Map<String, Object> sharedClaims, String passportSessionId) {
+    @JsonProperty("redirect_uri")
+    private String redirectUrl;
+
+    public JarResponse(
+            Map<String, Object> sharedClaims, String passportSessionId, String redirectUrl) {
         this.sharedClaims = sharedClaims;
         this.passportSessionId = passportSessionId;
+        this.redirectUrl = redirectUrl;
     }
 
     public Map<String, Object> getSharedClaims() {


### PR DESCRIPTION
## Proposed changes

### What changed

- New `redirect_uri` parameter added to object  passed from BE to FE

### Why did it change

- FE was not provided with `redirect_uri` parameter from BE.
See: https://github.com/alphagov/di-ipv-cri-uk-passport-front/pull/441

### Issue tracking

- [LIME-399](https://govukverify.atlassian.net/browse/LIME-399)

[LIME-399]: https://govukverify.atlassian.net/browse/LIME-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ