### PR TITLE
LIME-529 - Pinned gradle version 7.6

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Build and unit tests
         run: ./gradlew clean build
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
 #      - name: Set up AWS creds for integration tests
 #        uses: aws-actions/configure-aws-credentials@v1
 #        with:
@@ -62,3 +67,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonarqube
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3


### PR DESCRIPTION
### What changed

Pinned gradle version 7.6

### Why did it change

Codebase supports gradle version 7.6