### PR TITLE
LIME-567: Enabling VC expiry removal in prod

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -81,7 +81,7 @@ Mappings:
       build: "true"
       staging: "true"
       integration: "true"
-      production: "false"
+      production: "true"
 
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabled VC expiry removal in production

### Why did it change

So that IPV core and spot can more freely control expirys of VCs

