### PR TITLE
LIME-384: Increasing alarm threshold to avoid false alarms during periods of low traffic

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -913,8 +913,8 @@ Resources:
       OKActions:
         - !Ref AlarmTopicPassport
       InsufficientDataActions: [ ]
-      DatapointsToAlarm: 6
-      EvaluationPeriods: 6
+      DatapointsToAlarm: 10
+      EvaluationPeriods: 10
       Threshold: 1
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
## Proposed changes

### What changed

Adjusted thresholds on lambda deviations

### Why did it change

To avoid false alarms on period of low traffic

