### PR TITLE
LIME-603: Fixed failing passport staging tests

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PagesFromIpvCoreRepo/EnterPassportDetailsPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PagesFromIpvCoreRepo/EnterPassportDetailsPage.java
@@ -346,12 +346,31 @@ public class EnterPassportDetailsPage extends GlobalPage {
     }
 
     public void cookieupdatecy() {
-        Cookie cookie = new Cookie("lng", "cy");
-        Cookie cookie1 = new Cookie("lang", "cy");
+        changeLanguageTo("Welsh");
+    }
+
+    public void changeLanguageTo(final String language) {
+        BrowserUtils.waitForPageToLoad(10);
+        String languageCode = "eng";
+        switch (language) {
+            case "Welsh":
+                {
+                    languageCode = "cy";
+                }
+        }
+
+        String currentURL = Driver.get().getCurrentUrl();
+        String newURL = currentURL + "/?lang=" + languageCode;
+        Driver.get().get(newURL);
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    public void updateLanguageCookiesDirect(final String language) {
+        driver.manage().deleteCookieNamed("lng");
+        Cookie cookie = new Cookie("lng", language);
         Driver.get().manage().addCookie(cookie);
-        Driver.get().manage().addCookie(cookie1);
-        Driver.get().navigate().refresh();
-        BrowserUtils.waitFor(2);
+        Driver.get().navigate().to(driver.getCurrentUrl());
+        BrowserUtils.waitForPageToLoad(10);
     }
 
     public void weleshLngGOVUKPage() {

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PagesFromIpvCoreRepo/EnterPassportDetailsPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/pages/PagesFromIpvCoreRepo/EnterPassportDetailsPage.java
@@ -373,7 +373,7 @@ public class EnterPassportDetailsPage extends GlobalPage {
         BrowserUtils.waitForPageToLoad(10);
     }
 
-    public void weleshLngGOVUKPage() {
+    public void welshLngGOVUKPage() {
         Assert.assertEquals("Cwcis ar GOV.UK One Login", getText(COOKIE_BANNER_GOVUK));
         Assert.assertEquals(
                 "Dechrau profi pwy ydych chi gyda GOV.UK One Login", getText(GOVUK_HDR));

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/CommonSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/CommonSteps.java
@@ -3,15 +3,18 @@ package uk.gov.di.ipv.cri.passport.acceptance_tests.step_definitions;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.pages.OrchestratorStubPage;
+import uk.gov.di.ipv.cri.passport.acceptance_tests.service.ConfigurationService;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.BrowserUtils;
-import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.ConfigurationReader;
 import uk.gov.di.ipv.cri.passport.acceptance_tests.utilities.Driver;
 
 public class CommonSteps {
 
+    private final ConfigurationService configurationService =
+            new ConfigurationService(System.getenv("ENVIRONMENT"));
+
     @Given("I am on Orchestrator Stub")
     public void i_am_on_orchestrator_stub() {
-        Driver.get().get(ConfigurationReader.getOrchestratorUrl());
+        Driver.get().get(configurationService.getOrchestratorStubUrl());
         BrowserUtils.waitForPageToLoad(10);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/LoginSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/LoginSteps.java
@@ -111,7 +111,7 @@ public class LoginSteps {
             LOGGER.warning(
                     "No environment variable specified, please specify a variable for runs in Integration");
         }
-        //            passportDocCheckPage.waitForPageToLoad();
+        passportDocCheckPage.waitForPageToLoad();
         passportDocCheckPage.passportDocCheck();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/PassportCriSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/PassportCriSteps.java
@@ -125,7 +125,7 @@ public class PassportCriSteps {
 
     @Then("the content is displayed in Welsh language in GOVUK account page")
     public void theContentIsDisplayedInWelshLanguageInGOVUKAccountPage() {
-        enterPassportDetailsPage.weleshLngGOVUKPage();
+        enterPassportDetailsPage.welshLngGOVUKPage();
     }
 
     @Then("the content is displayed in Welsh language in Passport CRI Page")

--- a/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/PassportCriSteps.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/ipv/cri/passport/acceptance_tests/step_definitions/stepDefsFromIpvRepo/PassportCriSteps.java
@@ -118,6 +118,11 @@ public class PassportCriSteps {
         enterPassportDetailsPage.cookieupdatecy();
     }
 
+    @When("user updated cookies can see the non CRI content in Welsh")
+    public void userUpdatedCookiesCanSeeTheNonCRIContentInWelsh() {
+        enterPassportDetailsPage.updateLanguageCookiesDirect("cy");
+    }
+
     @Then("the content is displayed in Welsh language in GOVUK account page")
     public void theContentIsDisplayedInWelshLanguageInGOVUKAccountPage() {
         enterPassportDetailsPage.weleshLngGOVUKPage();

--- a/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/PassportCRITests.feature
+++ b/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/PassportCRITests.feature
@@ -7,6 +7,7 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then User should be on Address CRI Page
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject             |
@@ -24,6 +25,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid passport number should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject      |
       |InvalidPassportNumber|
@@ -35,6 +38,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Surname should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject |
       |Invalidsurname  |
@@ -46,6 +51,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid First Name should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject |
       |InvalidfirstName|
@@ -57,6 +64,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Date of Birth should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject   |
       |InvalidDateofBirth|
@@ -68,6 +77,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Expiry Date should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject  |
       |InvalidExpiryDate|
@@ -79,6 +90,8 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User adds Invalid "<InvalidPassportSubject>" and then adds valid "<PassportSubject>"
     Then User should be on Address CRI Page
+    Then The test is complete and I close the driver
+
     Examples:
       |InvalidPassportSubject  | PassportSubject           |
       |PassportSubjectInvalid  | PassportSubjectHappyDanny |
@@ -91,6 +104,8 @@ Feature: Passport Test (Full Journey Route)
     When User adds Invalid "<InvalidPassportSubject>"
     And  adds again Invalid "<InvalidPassportSubject>"
     Then we cannot prove your identity right now error page is displayed
+    Then The test is complete and I close the driver
+
     Examples:
       |InvalidPassportSubject |
       |PassportSubjectInvalid |
@@ -102,6 +117,7 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User clicks prove your identity in another way
     Then  Prove your identity in another way is displayed
+    Then The test is complete and I close the driver
 
   @Staging @Integration @PYIC-1636
   Scenario Outline: Passport Escape route Passport Retry
@@ -111,6 +127,7 @@ Feature: Passport Test (Full Journey Route)
     When User clicks Try to Enter Passport details and redirected back to passport page
     And User "<PassportSubject>" adds their passport details
     Then User should be on Address CRI Page
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject            |
@@ -123,6 +140,7 @@ Feature: Passport Test (Full Journey Route)
     And clicks continue on the signed into your GOV.UK One Login page
     When User adds Invalid "<InvalidPassportSubject>" and then adds through retry valid "<PassportSubject>"
     Then User should be on Address CRI Page
+    Then The test is complete and I close the driver
 
     Examples:
       |InvalidPassportSubject  | PassportSubject           |
@@ -137,6 +155,7 @@ Feature: Passport Test (Full Journey Route)
     And User clicks Try to Enter Passport details and redirected back to passport page
     And  adds again Invalid "<InvalidPassportSubject>"
     Then we cannot prove your identity right now error page is displayed
+    Then The test is complete and I close the driver
 
     Examples:
       |InvalidPassportSubject  |
@@ -172,4 +191,6 @@ Feature: Passport Test (Full Journey Route)
     And I click continue
     Then I should be on the core stub Verifiable Credentials page
     And I should see passport data in JSON
+    Then The test is complete and I close the driver
+
 #    And Expiry time should be 6 months from the nbf in the JSON payload

--- a/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/Weleshtranslation.feature
+++ b/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/Weleshtranslation.feature
@@ -1,17 +1,12 @@
 Feature: Welsh Language Test
 
-  @Smoke_test @Staging @Integration
-  Scenario: The content in GOV.UK account page displayed in Welsh
-    Given User on Orchestrator Stub and click on full journey route
-    When  user updated cookies can see the stub content in Welsh
-    Then the content is displayed in Welsh language in GOVUK account page
-
   @Staging @Integration
   Scenario: The content in Passport CRI page displayed in Welsh
     Given User on Orchestrator Stub and click on full journey route
     And clicks continue on the signed into your GOV.UK account page
     When user updated cookies can see the stub content in Welsh
     Then the content is displayed in Welsh language in Passport CRI Page
+    Then The test is complete and I close the driver
 
   @Smoke_test @Staging @Integration @staging
   Scenario Outline: Passport Journey in Welsh translation Happy Path
@@ -20,6 +15,7 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then User should be on Address CRI Page
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject             |
@@ -32,6 +28,7 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid passport number should be displayed in Welsh
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject       |
@@ -44,6 +41,7 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid first name should be displayed in Welsh
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject  |
@@ -56,6 +54,7 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid surname should be displayed in Welsh
+    Then The test is complete and I close the driver
 
     Examples:
       |PassportSubject |
@@ -68,6 +67,8 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid dob should be displayed in Welsh
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject    |
       |InvalidDateofBirth |
@@ -79,6 +80,8 @@ Feature: Welsh Language Test
     And user updated cookies can see the stub content in Welsh
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid exp date should be displayed in Welsh
+    Then The test is complete and I close the driver
+
     Examples:
       |PassportSubject  |
       |InvalidExpiryDate|
@@ -89,8 +92,9 @@ Feature: Welsh Language Test
     And clicks continue on the signed into your GOV.UK account page
     When User adds Invalid "<InvalidPassportSubject>"
     And  adds again Invalid "<InvalidPassportSubject>"
-    And user updated cookies can see the stub content in Welsh
+    And user updated cookies can see the non CRI content in Welsh
     Then we cannot prove your identity right now error page is displayed in Welsh
+    Then The test is complete and I close the driver
 
     Examples:
       |InvalidPassportSubject |
@@ -108,6 +112,7 @@ Feature: Welsh Language Test
     When user enters data in kbv stub and Click on submit data and generate auth code
     And user updated cookies can see the stub content in Welsh
     Then user should be successful in proving identity in Welsh
+    Then The test is complete and I close the driver
 
     Examples:
       | PassportSubject   |
@@ -120,6 +125,7 @@ Feature: Welsh Language Test
     And user does not enters the data in Passport stub and click on submit
     And user updated cookies can see the stub content in Welsh
     Then technical error page should be displayed in Welsh
+    Then The test is complete and I close the driver
 
 
 #  To be updated with New user with KBV questions enabled

--- a/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/passportCRIStub.feature
+++ b/acceptance-tests/src/test/resources/features/passport/TestsFromIpvCoreRepo/passportCRIStub.feature
@@ -7,6 +7,7 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then Appropriate "<StubValidJsonResponse>" response should be displayed
+    Then The test is complete and I close the driver
 
     Examples:
       | PassportSubject            |  StubValidJsonResponse |
@@ -24,6 +25,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid passport number should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | PassportSubject       |
       | InvalidPassportNumber |
@@ -35,6 +38,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid First Name should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | PassportSubject  |
       | InvalidfirstName |
@@ -46,6 +51,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Surname should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | PassportSubject |
       | Invalidsurname  |
@@ -57,6 +64,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Date of Birth should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | PassportSubject    |
       | InvalidDateofBirth |
@@ -68,6 +77,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User "<PassportSubject>" adds their passport details
     Then proper error message for invalid Expiry Date should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | PassportSubject   |
       | InvalidExpiryDate |
@@ -79,6 +90,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User adds Invalid "<InvalidPassportSubject>" and then adds valid "<PassportSubject>"
     Then Appropriate "<StubValidJsonResponse>" response should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | InvalidPassportSubject | PassportSubject           | StubValidJsonResponse |
       | PassportSubjectInvalid | PassportSubjectHappyDanny | StubValidJsonResponse |
@@ -91,6 +104,8 @@ Feature: Passport Test (Through Passport Stub)
     When User adds Invalid "<InvalidPassportSubject>"
     And  adds again Invalid "<InvalidPassportSubject>"
     Then Appropriate Error "<StubErrorJsonResponse>" response should be displayed
+    Then The test is complete and I close the driver
+
     Examples:
       | InvalidPassportSubject | StubErrorJsonResponse |
       | PassportSubjectInvalid | StubErrorJsonResponse |
@@ -102,6 +117,8 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User clicks prove your identity in another way
     Then we cannot prove your identity right now error page is displayed
+    Then The test is complete and I close the driver
+
 
   @PYIC-1636
   Scenario Outline: Passport Escape route happy path
@@ -110,6 +127,7 @@ Feature: Passport Test (Through Passport Stub)
     And I click on ukPassport
     When User adds Invalid "<InvalidPassportSubject>" and then adds through retry valid "<PassportSubject>"
     Then Appropriate "<StubValidJsonResponse>" response should be displayed
+    Then The test is complete and I close the driver
 
     Examples:
       |InvalidPassportSubject  | PassportSubject           | StubValidJsonResponse |
@@ -124,6 +142,7 @@ Feature: Passport Test (Through Passport Stub)
     And User clicks Try to Enter Passport details and redirected back to passport page
     And  adds again Invalid "<InvalidPassportSubject>"
     Then Appropriate Error "<StubErrorJsonResponse>" response should be displayed
+    Then The test is complete and I close the driver
 
     Examples:
       |InvalidPassportSubject  | StubErrorJsonResponse |


### PR DESCRIPTION
## Proposed changes

### What changed

Added code to close the driver after each test
Added code to ensure cookies are added to the correct domain
Added code to ensure pages are loaded before checks are performed

### Why did it change

So that the passport staging tests pass more reliably 

