### PR TITLE
LIME-697: Added functionality to allow performance testing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -970,6 +970,22 @@ Resources:
       Type: String
       Description: Expiry date release toggle
 
+  IsPerformanceStubParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${Environment}/credentialIssuers/ukPassport/self/release-flags/isPerformanceStub"
+      Type: String
+      Value: "false"
+      Description: Feature toggle to allow performance testing passed SSL
+
+  logDcsStubParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${Environment}/credentialIssuers/ukPassport/self/release-flags/logDcsResponse"
+      Type: String
+      Value: "false"
+      Description: Feature toggle to allow performance testing passed SSL
+
   ####################################################################
   #                                                                  #
   # Alarm setup                                                      #

--- a/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
+++ b/lambdas/checkpassport/src/main/java/uk/gov/di/ipv/cri/passport/checkpassport/CheckPassportHandler.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.MAXIMUM_ATTEMPT_COUNT;
+import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.PASSPORT_CRI_RELEASE_FLAG_LOG_DCS_RESPONSE;
 import static uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable.VERIFIABLE_CREDENTIAL_ISSUER;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DCS_CHECK_REQUEST_FAILED;
 import static uk.gov.di.ipv.cri.passport.library.metrics.Definitions.DCS_CHECK_REQUEST_SUCCEEDED;
@@ -182,6 +183,9 @@ public class CheckPassportHandler
                     AuditEventUser.fromPassportSessionItem(passportSessionItem);
             auditService.sendAuditEvent(createAuditEventResponseReceived(auditEventUser));
 
+            if (configurationService.isReleaseFlag(PASSPORT_CRI_RELEASE_FLAG_LOG_DCS_RESPONSE)) {
+                LOGGER.info("DCS response " + dcsResponse.getPayload());
+            }
             DcsResponse unwrappedDcsResponse = unwrapDcsResponse(dcsResponse);
 
             validateDcsResponse(unwrappedDcsResponse);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/config/ConfigurationVariable.java
@@ -29,8 +29,11 @@ public enum ConfigurationVariable {
     VERIFIABLE_CREDENTIAL_ISSUER(
             "/%s/credentialIssuers/ukPassport/self/verifiableCredentialIssuer"),
     VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID(
-            "/%s/credentialIssuers/ukPassport/self/verifiableCredentialKmsSigningKeyId");
-
+            "/%s/credentialIssuers/ukPassport/self/verifiableCredentialKmsSigningKeyId"),
+    PASSPORT_CRI_RELEASE_FLAG_IS_PERFORMANCE_STUB(
+            "/%s/credentialIssuers/ukPassport/self/release-flags/isPerformanceStub"),
+    PASSPORT_CRI_RELEASE_FLAG_LOG_DCS_RESPONSE(
+            "/%s/credentialIssuers/ukPassport/self/release-flags/logDcsResponse");
     private final String value;
 
     ConfigurationVariable(String value) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/HttpClientSetUp.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/passport/library/helpers/HttpClientSetUp.java
@@ -4,6 +4,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import uk.gov.di.ipv.cri.passport.library.config.ConfigurationService;
+import uk.gov.di.ipv.cri.passport.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.cri.passport.library.exceptions.HttpClientException;
 
 import javax.net.ssl.SSLContext;
@@ -45,6 +46,10 @@ public class HttpClientSetUp {
                             configurationService.getCertificate(DCS_TLS_INTERMEDIATE_CERT)
                         });
 
+        if (configurationService.isReleaseFlag(
+                ConfigurationVariable.PASSPORT_CRI_RELEASE_FLAG_IS_PERFORMANCE_STUB)) {
+            return contextSetup(keystoreTLS, null);
+        }
         return contextSetup(keystoreTLS, trustStore);
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added feature toggle for performance testing
Added logging to work around issue of different certificates across environments. Manual steps required for now

### Why did it change

To enable performance testing the passport CRI

