### PR TITLE
LIME-697: Fixing broken github action

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -25,8 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
-          cache: gradle
+          distribution: zulu
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
## Proposed changes

### What changed

Fixed failing github action

### Why did it change

deploy to build was attempting to pull from an invalid cache object

