### PR TITLE
LIME-698: Added provisioned concurrency to build for perf testing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -62,7 +62,7 @@ Mappings:
     development-c:
       provisionedConcurrency: 0
     build:
-      provisionedConcurrency: 0
+      provisionedConcurrency: 1
     staging:
       provisionedConcurrency: 1
     integration:


### PR DESCRIPTION
## Proposed changes

### What changed

Added provisioned concurrency to build

### Why did it change

To enable performance testing 

