### PR TITLE
LIME-706: Adding basic lambda to capture TxMA events in dev and build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -676,6 +676,9 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: IsNotProdLikeEnvironment
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+      # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-passport-capture-audit-events-${Environment}"
       Handler: uk.gov.di.ipv.cri.passport.captureAuditEvents.CaptureAuditEventsHandler::handleRequest
       Runtime: java11
@@ -684,6 +687,7 @@ Resources:
       Architectures:
         - arm64
       Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-captureAuditEvents"
       Policies:
@@ -713,7 +717,9 @@ Resources:
     Condition: IsNotProdLikeEnvironment
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
-      RetentionInDays: 30
+      RetentionInDays: 14
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
 
   DCSResponseTable:
     Type: AWS::DynamoDB::Table

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,6 +127,12 @@ Conditions:
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
+  IsProdLikeEnvironment: !Or
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
+  IsNotProdLikeEnvironment: !Not
+    - Condition: IsProdLikeEnvironment
 
 Resources:
   IPVCriUKPassportPrivateAPI:
@@ -660,6 +666,54 @@ Resources:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref IPVCriUKPassportInitialiseSessionFunctionLogGroup
+
+
+  ##############################
+  # Stub Audit Event Consumer  #
+  ##############################
+
+  AuditEventConsumerFunction:
+    Type: AWS::Serverless::Function
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      FunctionName: !Sub "ipv-passport-capture-audit-events-${Environment}"
+      Handler: uk.gov.di.ipv.cri.passport.captureAuditEvents.CaptureAuditEventsHandler::handleRequest
+      Runtime: java11
+      PackageType: Zip
+      CodeUri: ../lambdas/captureAuditEvents
+      Architectures:
+        - arm64
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-captureAuditEvents"
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - Statement:
+            - Effect: Allow
+              Action:
+                - "sqs:SendMessage"
+                - "sqs:ReceiveMessage"
+                - "sqs:DeleteMessage"
+                - "sqs:GetQueueAttributes"
+              Resource:
+                - !Sub
+                  - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+                  - queueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
+
+  AuditEventConsumerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AuditEventConsumerFunction}"
+      RetentionInDays: 30
 
   DCSResponseTable:
     Type: AWS::DynamoDB::Table

--- a/lambdas/captureAuditEvents/build.gradle
+++ b/lambdas/captureAuditEvents/build.gradle
@@ -1,0 +1,84 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+plugins {
+	id "java"
+	id "idea"
+	id "jacoco"
+	id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
+}
+
+dependencies {
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:nimbus-jose-jwt:$rootProject.ext.dependencyVersions.nimbusJoseJwt",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			project(":lib"),
+			configurations.cri_common_lib
+
+	aspect "software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-metrics:$rootProject.ext.dependencyVersions.powertoolsMetrics"
+
+	testImplementation "com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-core:4.1.0",
+			"org.mockito:mockito-inline:2.13.0",
+			"org.mockito:mockito-junit-jupiter:4.1.0",
+			project(":lib").sourceSets.test.output
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+}
+
+task buildZip(type: Zip) {
+	from compileJava
+	from processResources
+	destinationDirectory = file("$rootDir/dist")
+	into("lib") {
+		from configurations.runtimeClasspath
+	}
+}
+
+test {
+	useJUnitPlatform ()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
+}
+
+tasks.withType(Test) {
+	testLogging {
+		events TestLogEvent.FAILED,
+				TestLogEvent.PASSED,
+				TestLogEvent.SKIPPED
+
+		exceptionFormat TestExceptionFormat.FULL
+		showExceptions true
+		showCauses true
+		showStackTraces true
+
+		afterSuite { suite, result ->
+			if (!suite.parent) {
+				def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+				def startItem = "|  ", endItem = "  |"
+				def repeatLength = startItem.length() + output.length() + endItem.length()
+				println("\n" + ("-" * repeatLength) + "\n" + startItem + output + endItem + "\n" + ("-" * repeatLength))
+			}
+		}
+	}
+}

--- a/lambdas/captureAuditEvents/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/CaptureAuditEventsHandler.java
+++ b/lambdas/captureAuditEvents/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/CaptureAuditEventsHandler.java
@@ -1,0 +1,36 @@
+package uk.gov.di.ipv.cri.passport.initialisesession;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
+import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
+
+
+public class CaptureAuditEventsHandler implements RequestHandler<SQSEvent, Void> {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public CaptureAuditEventsHandler() {
+    }
+
+    @Override
+    @Logging(clearState = true, correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
+    @Metrics(captureColdStart = true)
+    public Void handleRequest(
+            SQSEvent input, Context context) {
+        LogHelper.attachComponentIdToLogs();
+        try {
+            for(SQSEvent.SQSMessage msg : input.getRecords()){
+                LOGGER.info("Audit event consumed", msg.getEventSource(), "messageBody: " + msg.getBody());
+            }
+            return null;
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/lambdas/captureAuditEvents/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/CaptureAuditEventsHandler.java
+++ b/lambdas/captureAuditEvents/src/main/java/uk/gov/di/ipv/cri/passport/initialisesession/CaptureAuditEventsHandler.java
@@ -10,22 +10,22 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.cri.passport.library.helpers.LogHelper;
 
-
 public class CaptureAuditEventsHandler implements RequestHandler<SQSEvent, Void> {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public CaptureAuditEventsHandler() {
-    }
+    public CaptureAuditEventsHandler() {}
 
     @Override
     @Logging(clearState = true, correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
     @Metrics(captureColdStart = true)
-    public Void handleRequest(
-            SQSEvent input, Context context) {
+    public Void handleRequest(SQSEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            for(SQSEvent.SQSMessage msg : input.getRecords()){
-                LOGGER.info("Audit event consumed", msg.getEventSource(), "messageBody: " + msg.getBody());
+            for (SQSEvent.SQSMessage msg : input.getRecords()) {
+                LOGGER.info(
+                        "Audit event consumed",
+                        msg.getEventSource(),
+                        "messageBody: " + msg.getBody());
             }
             return null;
 

--- a/lambdas/captureAuditEvents/src/main/resources/log4j2.yaml
+++ b/lambdas/captureAuditEvents/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Console:
+      name: JsonAppender
+      target: SYSTEM_OUT
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:LambdaJsonLayout.json"
+  Loggers:
+    logger:
+      - name: JsonLogger
+        level: info
+        additivity: false
+        AppenderRef:
+          ref: JsonAppender
+    Root:
+      level: info
+      AppenderRef:
+        ref: JsonAppender
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,6 @@ include "lib",
 		"lambdas:checkpassport",
 		"lambdas:buildclientoauthresponse",
 		"lambdas:initialisesession",
+		"lambdas:captureAuditEvents",
 		"integration-test",
 		"acceptance-tests"


### PR DESCRIPTION
## Proposed changes

### What changed

Added new capture audit events lambda
Updated template to allow new lambda to read from the audit queue
Limited new lambda to dev and build

### Why did it change

To allow performance testing without overloading the TxMA service

