### PR TITLE
LIME-706: added missing event mapping to trigger audit lambda as required

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -4,7 +4,7 @@ Description: ipv-cri-uk-passport-back
 
 Globals:
   Function:
-    Timeout: 40
+    Timeout: 30
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -720,6 +720,16 @@ Resources:
       RetentionInDays: 14
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
+  AuditEventConsumerFunctionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      BatchSize: 10
+      Enabled: true
+      EventSourceArn: !Sub
+        - "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}"
+        - queueName: !ImportValue AuditEventQueueName
+      FunctionName: !Ref AuditEventConsumerFunction
 
   DCSResponseTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
## Proposed changes

### What changed

Added function event source mapping

### Why did it change

So that the new lambda is triggered on audit queue writes

