### PR TITLE
LIME-706: Updated memory for lambda audit consumer

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -684,6 +684,7 @@ Resources:
       Runtime: java11
       PackageType: Zip
       CodeUri: ../lambdas/captureauditevents
+      MemorySize: 1024
       Architectures:
         - arm64
       Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Fixed memory size for new lambda

